### PR TITLE
Feature-addText-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ The script will not perform a rename if it would lead to name collisions (i.e. s
 |`-n, -numericTransform`|`[sequential \| even \| odd]`|Rename files by using either a sequence (n+1), even (2n), or odd (2n+1) numbering algorithm. Defaults to `sequence`. To help with file-sorting, the number of digits will always be one more than the (so, a list of 10 files will use three digits: 001, 002 ...) |
 |`-d --dateRename`|`<creationDate, lastAccessed, lastModifies>`| Use date-related file information to rename a file. Defaults to `creationDate`. Can be used together wit the `--detailedDate` flag to add time information.|
 |`-s, --searchAndReplace`|`<string\|regex> <replacer>`|Takes a string or a regex filter argument and a replacer string. By default, the transform will preserve file extensions, unless a `--noPreserveExtension` option is supplied|
-|`-t, --truncate`|`<number>`|Truncate the baseName. Can be used in combination with other transform types or on its own. If preserveOriginal is false or customText is supplied, it has no effect.|
+|`-t, --truncate`|`<number>`|Truncate the baseName. Can be used in combination with other transform types or on its own. If preserveOriginal is false or addText is supplied, it has no effect.|
+|`-a, --addText`|`<string>`|Text to add to the target filename. Can be used on its own, together with 'textPosition' flag, or in combination with other transform types. Overwrites the `preserveOriginal` flag.|
 |`-f, --folderPath`|`<path>`|Folder in which the transformation should take place. *Can also be set implicitly* with an extra script argument (explicit setting takes precedence). If omitted, the script defaults to current working directory.|
 |`-r, --restore`||Restore transformed files to original names, if restore file is available.|
 |`-D, --dryRun`||Run transform operation without writing to disk. Expected output will be logged to console.|
@@ -60,8 +61,7 @@ The script will not perform a rename if it would lead to name collisions (i.e. s
 |`-e, --exclude`|`<string\|regex>`|Preemptively exclude files that match a given string or regular expression from being evaluated in the transform functions|
 |`-p, --preserveOriginal`|`[boolean]`| Preserve original file name. Not relevant for the `searchAndReplace` transform type. Defaults to `true`.|
 |`--noPreserveExtension`||An option for the 'searchAndPreserve' transform which includes the file extension in the transform operation.|
-|`-c, --customText`|`<string>`|Text to add to the transformed name. Overwrites the `preserveOriginal` flag.|
-|`--textPosition`|`[prepend \| append]`|Applies to `preserveOriginal` or `customText`. Specifies where original or custom text should be appended with respect to the transformation text. Defaults to `append`|
+|`--textPosition`|`[prepend \| append]`|Applies to `preserveOriginal` or `addText`. Specifies where original or custom text should be appended with respect to the transformation text. Defaults to `append`|
 |`--detailedDate`||Appends time information (`T hh:mm:ss`) to date transformations.|
 |`--separator`|`<character>`|Specify a custom character which will be used as a separator in the dateTransformation and between the original|custom text and the transform text. Can be an empty string (in this case it will be ignored in date formatting). Defaults to hyphen (`-`).|
 |`--cleanRollback`||Remove rollback file.|

--- a/src/commands/parseCommands.ts
+++ b/src/commands/parseCommands.ts
@@ -1,19 +1,19 @@
 import {
-  INCLUSIVE_TRANSFORM_TYPES,
-  UTILITY_ACTIONS,
-  VALID_TRANSFORM_TYPES,
+    INCLUSIVE_TRANSFORM_TYPES,
+    UTILITY_ACTIONS,
+    VALID_TRANSFORM_TYPES
 } from "../constants.js";
 import { convertFiles } from "../converters/converter.js";
 import { checkPath } from "../converters/utils.js";
 import { ERRORS } from "../messages/errMessages.js";
 import type {
-  OptionKeysWithValues,
-  OptionKeysWithValuesAndRestArgs,
-  RenameListArgs,
-  SetTransformationPath,
-  TransformTypes,
-  UtilityActions,
-  UtilityActionsCheck,
+    OptionKeysWithValues,
+    OptionKeysWithValuesAndRestArgs,
+    RenameListArgs,
+    SetTransformationPath,
+    TransformTypes,
+    UtilityActions,
+    UtilityActionsCheck
 } from "../types";
 import program from "./generateCommands.js";
 import { utilityActionsCorrespondenceTable } from "./programConfiguration.js";
@@ -30,7 +30,7 @@ export const parseOptions = async (
   try {
     if (!Object.keys(options).length) return program.help();
     const {
-      customText,
+      addText,
       separator,
       textPosition,
       preserveOriginal,
@@ -70,7 +70,7 @@ export const parseOptions = async (
       transformedPreserve = true;
     }
     const args = {
-      customText,
+      addText,
       transformPattern,
       preserveOriginal: transformedPreserve,
       noExtensionPreserve,

--- a/src/commands/parseCommands.ts
+++ b/src/commands/parseCommands.ts
@@ -1,26 +1,24 @@
 import {
-    INCLUSIVE_TRANSFORM_TYPES,
-    UTILITY_ACTIONS,
-    VALID_TRANSFORM_TYPES
+  UTILITY_ACTIONS,
+  VALID_TRANSFORM_TYPES
 } from "../constants.js";
 import { convertFiles } from "../converters/converter.js";
 import { checkPath } from "../converters/utils.js";
 import { ERRORS } from "../messages/errMessages.js";
 import type {
-    OptionKeysWithValues,
-    OptionKeysWithValuesAndRestArgs,
-    RenameListArgs,
-    SetTransformationPath,
-    TransformTypes,
-    UtilityActions,
-    UtilityActionsCheck
+  OptionKeysWithValues,
+  OptionKeysWithValuesAndRestArgs,
+  RenameListArgs,
+  SetTransformationPath,
+  TransformTypes,
+  UtilityActions,
+  UtilityActionsCheck
 } from "../types";
 import program from "./generateCommands.js";
 import { utilityActionsCorrespondenceTable } from "./programConfiguration.js";
 
 const {
   COMMAND_NO_TRANSFORMATION_PICKED,
-  COMMAND_ONLY_ONE_EXCLUSIVE_TRANSFORM,
   COMMAND_ONLY_ONE_UTILITY_ACTION,
 } = ERRORS;
 
@@ -104,17 +102,8 @@ export const transformationCheck = (
       options[key]
   );
   const numOfTransformations = transformationPicked.length;
-  const numOfExclusiveTransformations = transformationPicked.filter(
-    (transformationType) =>
-      !INCLUSIVE_TRANSFORM_TYPES.some(
-        (inclusiveType) => inclusiveType === transformationType
-      )
-  ).length;
   if (!numOfTransformations) {
     throw new Error(COMMAND_NO_TRANSFORMATION_PICKED);
-  }
-  if (numOfExclusiveTransformations > 1) {
-    throw new Error(COMMAND_ONLY_ONE_EXCLUSIVE_TRANSFORM);
   }
   return transformationPicked as TransformTypes[];
 };

--- a/src/commands/programConfiguration.ts
+++ b/src/commands/programConfiguration.ts
@@ -34,7 +34,7 @@ const programOptions: ProgramOptions[] = [
     short: "t",
     long: "truncate",
     description:
-      "Truncate the baseName. Can be used in combination with other transform types or on its own. If preserveOriginal is false or customText is supplied, it has no effect.",
+      "Truncate the baseName. Can be used in combination with other transform types or on its own. If preserveOriginal is false or addText is supplied, it has no effect.",
     type: "<number>",
     defaultValue: "",
   },
@@ -95,18 +95,18 @@ const programOptions: ProgramOptions[] = [
     defaultValue: "",
   },
   {
-    short: "c",
-    long: "customText",
+    short: "a",
+    long: "addText",
     type: "<name>",
     description:
-      "Text to add to the transformed name. Overwrites the 'preserveOriginal' flag.",
+      "Text to add to the target filename. Can be used on its own, together with 'textPosition' flag, or in combination with other transform types. Overwrites the `preserveOriginal` flag.",
     defaultValue: "",
   },
   {
     short: "",
     long: "textPosition",
     description:
-      "Applies to 'preserveOriginal' or 'customText'. Specifies where original or custom text should be appended with respect to the transformation text. Defaults to 'append'",
+      "Applies to 'preserveOriginal' or 'addText'. Specifies where original or custom text should be appended with respect to the transformation text. Defaults to 'append'",
     type: "[position]",
     choices: ["prepend", "append"],
     defaultValue: "append",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,13 +9,6 @@ export const VALID_TRANSFORM_TYPES = [
   "addText",
 ] as const;
 
-export const INCLUSIVE_TRANSFORM_TYPES = ["truncate", "addText"] as const;
-export const EXCLUSIVE_TRANSFORM_TYPES = VALID_TRANSFORM_TYPES.filter(
-  (transformType) =>
-    !INCLUSIVE_TRANSFORM_TYPES.some(
-      (inclusiveType) => inclusiveType === transformType
-    )
-);
 export const VALID_DATE_TRANSFORM_TYPES = [
   "creationDate",
   "lastAccessed",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,4 @@
+
 export const DEFAULT_SEPARATOR = "-";
 export const ROLLBACK_FILE_NAME = ".rollback.json";
 export const VALID_TRANSFORM_TYPES = [
@@ -5,9 +6,10 @@ export const VALID_TRANSFORM_TYPES = [
   "dateRename",
   "searchAndReplace",
   "truncate",
+  "addText",
 ] as const;
 
-export const INCLUSIVE_TRANSFORM_TYPES = ["truncate"] as const;
+export const INCLUSIVE_TRANSFORM_TYPES = ["truncate", "addText"] as const;
 export const EXCLUSIVE_TRANSFORM_TYPES = VALID_TRANSFORM_TYPES.filter(
   (transformType) =>
     !INCLUSIVE_TRANSFORM_TYPES.some(

--- a/src/converters/addTextTransform.ts
+++ b/src/converters/addTextTransform.ts
@@ -1,0 +1,31 @@
+import type { AddTextTransform } from "../types.js";
+import { composeRenameString, truncateFile } from "./utils.js";
+
+export const addTextTransform: AddTextTransform = ({
+  splitFileList,
+  textPosition,
+  separator,
+  truncate,
+  addText,
+}) => {
+  return splitFileList.map((fileInfo) => {
+    const { baseName:_baseName, ext, sourcePath } = fileInfo;
+    const baseName = truncate
+      ? truncateFile({
+          preserveOriginal: true,
+          baseName: _baseName,
+          truncate,
+        })
+      : _baseName;
+    const rename = composeRenameString({
+      baseName,
+      ext,
+      separator,
+      textPosition,
+      newName: baseName,
+      addText,
+    });
+    const original = `${baseName}${ext}`;
+    return { original, rename, sourcePath };
+  });
+};

--- a/src/converters/addTextTransform.ts
+++ b/src/converters/addTextTransform.ts
@@ -1,5 +1,5 @@
 import type { AddTextTransform } from "../types.js";
-import { composeRenameString } from "./utils.js";
+import { composeRenameString, truncateFile } from "./utils.js";
 
 export const addTextTransform: AddTextTransform = ({
   splitFileList,
@@ -10,13 +10,17 @@ export const addTextTransform: AddTextTransform = ({
 }) => {
   return splitFileList.map((fileInfo) => {
     const { baseName, ext, sourcePath } = fileInfo;
+    let newName = baseName;
+    if(truncate) {
+      newName = truncateFile({baseName, preserveOriginal:true, truncate});
+    }
     const rename = composeRenameString({
       baseName: baseName,
-      newName: addText!,
+      newName,
+      addText: addText!,
       ext,
       separator,
       textPosition,
-      truncate,
       preserveOriginal: true,
     });
     const original = `${baseName}${ext}`;

--- a/src/converters/addTextTransform.ts
+++ b/src/converters/addTextTransform.ts
@@ -1,29 +1,23 @@
 import type { AddTextTransform } from "../types.js";
-import { composeRenameString, truncateFile } from "./utils.js";
+import { composeRenameString } from "./utils.js";
 
 export const addTextTransform: AddTextTransform = ({
   splitFileList,
   textPosition,
   separator,
   truncate,
-  addText,
+  addText
 }) => {
   return splitFileList.map((fileInfo) => {
-    const { baseName:_baseName, ext, sourcePath } = fileInfo;
-    const baseName = truncate
-      ? truncateFile({
-          preserveOriginal: true,
-          baseName: _baseName,
-          truncate,
-        })
-      : _baseName;
+    const { baseName, ext, sourcePath } = fileInfo;
     const rename = composeRenameString({
-      baseName,
+      baseName: baseName,
+      newName: addText!,
       ext,
       separator,
       textPosition,
-      newName: baseName,
-      addText,
+      truncate,
+      preserveOriginal: true,
     });
     const original = `${baseName}${ext}`;
     return { original, rename, sourcePath };

--- a/src/converters/converter.ts
+++ b/src/converters/converter.ts
@@ -1,8 +1,6 @@
 import { writeFile } from "fs/promises";
 import { resolve } from "path";
-import {
-  ROLLBACK_FILE_NAME, VALID_TRANSFORM_TYPES
-} from "../constants.js";
+import { ROLLBACK_FILE_NAME, VALID_TRANSFORM_TYPES } from "../constants.js";
 import { ERRORS } from "../messages/errMessages.js";
 import type {
   DryRunTransform,
@@ -26,15 +24,15 @@ import {
 } from "./utils.js";
 const { DUPLICATE_FILE_NAMES } = ERRORS;
 
-const TRANSFORM_CORRESPONDENCE_TABLE: Record<
+export const TRANSFORM_CORRESPONDENCE_TABLE: Record<
   typeof VALID_TRANSFORM_TYPES[number],
   Function
 > = {
-  addText: addTextTransform,
-  dateRename: dateTransform,
-  numericTransform,
-  searchAndReplace,
-  truncate: truncateTransform,
+  addText: (args: GenerateRenameListArgs) => addTextTransform(args),
+  dateRename: (args: GenerateRenameListArgs) => dateTransform(args),
+  numericTransform: (args: GenerateRenameListArgs) => numericTransform(args),
+  searchAndReplace: (args: GenerateRenameListArgs) => searchAndReplace(args),
+  truncate: (args: GenerateRenameListArgs) => truncateTransform(args),
 };
 
 export const convertFiles = async (args: RenameListArgs): Promise<void> => {
@@ -85,7 +83,7 @@ export const convertFiles = async (args: RenameListArgs): Promise<void> => {
 export const generateRenameList: GenerateRenameList = (args) => {
   const { transformPattern } = args;
   const primaryTransform = transformPattern[0];
- if (Object.keys(TRANSFORM_CORRESPONDENCE_TABLE).includes(primaryTransform)) {
+  if (Object.keys(TRANSFORM_CORRESPONDENCE_TABLE).includes(primaryTransform)) {
     return TRANSFORM_CORRESPONDENCE_TABLE[primaryTransform](args);
   }
   throw new Error(ERRORS.TRANSFORM_NO_FUNCTION_AVAILABLE);

--- a/src/converters/dateTransform.ts
+++ b/src/converters/dateTransform.ts
@@ -2,7 +2,6 @@ import { Stats } from "fs";
 import { stat } from "fs/promises";
 import { join } from "path";
 import { DEFAULT_SEPARATOR } from "../constants.js";
-import { ERRORS } from "../messages/errMessages.js";
 import type {
   DateTransform,
   DateTransformCorrespondenceTable,
@@ -12,8 +11,6 @@ import type {
   ProvideFileStats
 } from "../types";
 import { composeRenameString } from "./utils.js";
-
-const { DUPLICATE_FILE_NAMES } = ERRORS;
 
 export const provideFileStats: ProvideFileStats = async (splitFileList) => {
   const splitFileListWithStats: FileListWithStatsArray = await Promise.all(

--- a/src/converters/dateTransform.ts
+++ b/src/converters/dateTransform.ts
@@ -4,12 +4,12 @@ import { join } from "path";
 import { DEFAULT_SEPARATOR } from "../constants.js";
 import { ERRORS } from "../messages/errMessages.js";
 import type {
-  DateTransform,
-  DateTransformCorrespondenceTable,
-  FileListWithDates,
-  FileListWithStatsArray,
-  FormattedDate,
-  ProvideFileStats,
+    DateTransform,
+    DateTransformCorrespondenceTable,
+    FileListWithDates,
+    FileListWithStatsArray,
+    FormattedDate,
+    ProvideFileStats
 } from "../types";
 import { areNewNamesDistinct, composeRenameString } from "./utils.js";
 
@@ -55,7 +55,7 @@ export const extractDate = (milliseconds: number): FormattedDate => {
 export const dateTransform: DateTransform = ({
   splitFileList,
   dateRename,
-  customText,
+  addText,
   textPosition,
   preserveOriginal,
   detailedDate,
@@ -85,7 +85,7 @@ export const dateTransform: DateTransform = ({
       ext,
       preserveOriginal,
       newName: datePrefix,
-      customText,
+      addText,
       textPosition,
       separator,
       truncate,

--- a/src/converters/dateTransform.ts
+++ b/src/converters/dateTransform.ts
@@ -4,14 +4,14 @@ import { join } from "path";
 import { DEFAULT_SEPARATOR } from "../constants.js";
 import { ERRORS } from "../messages/errMessages.js";
 import type {
-    DateTransform,
-    DateTransformCorrespondenceTable,
-    FileListWithDates,
-    FileListWithStatsArray,
-    FormattedDate,
-    ProvideFileStats
+  DateTransform,
+  DateTransformCorrespondenceTable,
+  FileListWithDates,
+  FileListWithStatsArray,
+  FormattedDate,
+  ProvideFileStats
 } from "../types";
-import { areNewNamesDistinct, composeRenameString } from "./utils.js";
+import { composeRenameString } from "./utils.js";
 
 const { DUPLICATE_FILE_NAMES } = ERRORS;
 
@@ -98,7 +98,5 @@ export const dateTransform: DateTransform = ({
     };
   });
 
-  const areNamesDistinct = areNewNamesDistinct(transformedNames);
-  if (areNamesDistinct) return transformedNames;
-  throw new Error(DUPLICATE_FILE_NAMES);
+  return transformedNames;
 };

--- a/src/converters/numericTransform.ts
+++ b/src/converters/numericTransform.ts
@@ -5,7 +5,7 @@ import { composeRenameString } from "./utils.js";
 /**Return a list of odd|even names, along with original file names */
 export const numericTransform: NumericTransform = ({
   splitFileList,
-  customText,
+  addText,
   textPosition,
   preserveOriginal,
   numericTransform,
@@ -32,7 +32,7 @@ export const numericTransform: NumericTransform = ({
       ext,
       newName: stringifiedNum,
       preserveOriginal,
-      customText,
+      addText,
       textPosition,
       separator,
       truncate,

--- a/src/converters/truncateTransform.ts
+++ b/src/converters/truncateTransform.ts
@@ -5,7 +5,7 @@ const { TRUNCATE_NO_PRESERVE_ORIGINAL, TRUNCATE_INVALID_ARGUMENT } = ERRORS;
 
 export const truncateTransform: TruncateTransform = ({
   splitFileList,
-  customText,
+  addText,
   preserveOriginal,
   separator,
   textPosition,
@@ -23,7 +23,7 @@ export const truncateTransform: TruncateTransform = ({
     const rename = composeRenameString({
       baseName,
       ext,
-      customText,
+      addText,
       textPosition,
       separator,
       // Must set preserveOriginal to false, since we are already including it in newName

--- a/src/converters/utils.ts
+++ b/src/converters/utils.ts
@@ -121,7 +121,7 @@ export const composeRenameString: ComposeRenameString = ({
   
   let modifiedName = newName;
   
-  // Truncate baseName or add custom text.
+  // Truncate baseName OR add custom text.
   const shouldTruncate = !isNaN(Number(truncate)) && preserveOriginal;
   let baseName = _baseName;
   if (shouldTruncate)

--- a/src/converters/utils.ts
+++ b/src/converters/utils.ts
@@ -104,7 +104,7 @@ export const determineDir: DetermineDir = (transformPath) =>
 export const composeRenameString: ComposeRenameString = ({
   baseName: _baseName,
   ext,
-  customText,
+  addText,
   textPosition,
   separator,
   preserveOriginal,
@@ -126,8 +126,8 @@ export const composeRenameString: ComposeRenameString = ({
       preserveOriginal,
       truncate: truncate!,
     });
-  const additionalText = customText
-    ? customText
+  const additionalText = addText
+    ? addText
     : preserveOriginal
     ? baseName
     : "";

--- a/src/converters/utils.ts
+++ b/src/converters/utils.ts
@@ -16,6 +16,7 @@ import type {
   DetermineDir,
   ExtractBaseAndExt,
   ListFiles,
+  NumberOfDuplicatedNames,
   TruncateFileName
 } from "../types.js";
 
@@ -73,12 +74,39 @@ export const listFiles: ListFiles = async (transformPath, excludeFilter) => {
   return files;
 };
 
+/** Calls *numberOfDuplicatedNames* with the "results" checkType
+ * and then evaluates if the result is less or equal than 0.
+ */
 export const areNewNamesDistinct: AreNewNamesDistinct = (renameList) => {
-  const newNames = renameList.map((singleDatum) => singleDatum.rename);
-  const allDistinct = !newNames.some(
-    (newName) => newNames.filter((someName) => someName === newName).length > 1
-  );
-  return allDistinct;
+  const duplicates = numberOfDuplicatedNames({
+    renameList,
+    checkType: "results",
+  });
+  return duplicates <= 0;
+};
+
+/** Check for duplicated fileNames which would lead to errors. Takes in an
+ * @param args.renameList - Supply rename list of appropriate type.
+    @param {"results"|"transforms"} args.checkType - If 'results' are specified,functions checks if there are duplicated among the transformed names. 
+    If 'transforms' are specified, it checks whether there exist identical old and new names.
+ */
+
+export const numberOfDuplicatedNames: NumberOfDuplicatedNames = ({
+  renameList,
+  checkType,
+}) => {
+  if (checkType === "results") {
+    const renames = renameList.map((renameInfo) => renameInfo.rename);
+    let newNamesUniqueLength = new Set(renames).size;
+    return renames.length - newNamesUniqueLength;
+  }
+  if (checkType === "transforms") {
+    const duplicatedTransforms = renameList.filter(
+      (renameInfo) => renameInfo.original === renameInfo.rename
+    );
+    return duplicatedTransforms.length;
+  }
+  return -1;
 };
 
 export const checkPath: CheckPath = async (path) => {
@@ -118,9 +146,9 @@ export const composeRenameString: ComposeRenameString = ({
   // For undefined cases, force default separator, unless newName is falsy.
   if (separator) sep = separator;
   if (separator === undefined && newName) sep = DEFAULT_SEPARATOR;
-  
+
   let modifiedName = newName;
-  
+
   // Truncate baseName OR add custom text.
   const shouldTruncate = !isNaN(Number(truncate)) && preserveOriginal;
   let baseName = _baseName;

--- a/src/converters/utils.ts
+++ b/src/converters/utils.ts
@@ -115,9 +115,13 @@ export const composeRenameString: ComposeRenameString = ({
   const extension = ext ? ext : "";
   let sep = "";
   // Allow for empty separator (direct concatenation)
-  if (separator && separator.length) sep = separator;
-  if (separator === undefined) sep = DEFAULT_SEPARATOR;
+  // For undefined cases, force default separator, unless newName is falsy.
+  if (separator) sep = separator;
+  if (separator === undefined && newName) sep = DEFAULT_SEPARATOR;
+  
   let modifiedName = newName;
+  
+  // Truncate baseName or add custom text.
   const shouldTruncate = !isNaN(Number(truncate)) && preserveOriginal;
   let baseName = _baseName;
   if (shouldTruncate)
@@ -126,19 +130,21 @@ export const composeRenameString: ComposeRenameString = ({
       preserveOriginal,
       truncate: truncate!,
     });
-  const additionalText = addText
+  // Custom text overrides preserveOriginal setting.
+  const customOrOriginalText = addText
     ? addText
     : preserveOriginal
     ? baseName
     : "";
-  if (additionalText) {
+  if (customOrOriginalText) {
     if (position === "append") {
-      modifiedName = `${newName}${sep}${additionalText}`;
+      modifiedName = `${newName}${sep}${customOrOriginalText}`;
     }
     if (position === "prepend") {
-      modifiedName = `${additionalText}${sep}${newName}`;
+      modifiedName = `${customOrOriginalText}${sep}${newName}`;
     }
   }
+
   return `${modifiedName}${extension}`;
 };
 

--- a/src/messages/errMessages.ts
+++ b/src/messages/errMessages.ts
@@ -1,6 +1,5 @@
 import {
-  EXCLUSIVE_TRANSFORM_TYPES,
-  VALID_TRANSFORM_TYPES,
+  VALID_TRANSFORM_TYPES
 } from "../constants.js";
 
 export const ERRORS = {
@@ -21,9 +20,6 @@ export const ERRORS = {
   COMMAND_NO_TRANSFORMATION_PICKED: `No transformation operation picked! Please specify one of the following: ${VALID_TRANSFORM_TYPES.join(
     ", "
   )}.`,
-  COMMAND_ONLY_ONE_EXCLUSIVE_TRANSFORM: `You can only pick one exclusive (${EXCLUSIVE_TRANSFORM_TYPES.join(
-    ", "
-  )}) transformation type!`,
   TRANSFORM_NO_FUNCTION_AVAILABLE: `No transform function available for the chosen option!`,
   COMMAND_ONLY_ONE_UTILITY_ACTION:
     "Only one type of utility action can be executed at the time!",

--- a/src/tests/addTextTransform.spec.ts
+++ b/src/tests/addTextTransform.spec.ts
@@ -1,0 +1,58 @@
+import { addTextTransform } from "../converters/addTextTransform.js";
+import * as utils from "../converters/utils.js";
+import type { GenerateRenameListArgs } from "../types.js";
+import { generateMockSplitFileList } from "./mocks.js";
+let splitFileList = generateMockSplitFileList(2);
+const exampleArgs: GenerateRenameListArgs = {
+  addText: "addText",
+  textPosition: undefined,
+  separator: undefined,
+  truncate: undefined,
+  splitFileList,
+  transformPattern: ["addText"],
+};
+describe("addTextTransform", () => {
+  it("Should return appropriately shaped response", () => {
+    const renameList = addTextTransform(exampleArgs);
+    expect(renameList.length).toBe(splitFileList.length);
+    const expectedKeys = ["rename", "original", "sourcePath"];
+    const keys = Object.keys(renameList[0]);
+    keys.forEach((key) => {
+      expect(
+        renameList[0][key as keyof typeof renameList[0]]
+      ).not.toBeUndefined();
+    });
+  });
+  it("Should addText to fileList", () => {
+    const renameList = addTextTransform(exampleArgs);
+    renameList.forEach((renameInstance) => {
+      const { rename } = renameInstance;
+      expect(rename).toContain(exampleArgs.addText);
+    });
+  });
+  it("Should call composeRenameString with appropriate arguments", () => {
+    const spyOnCompose = jest.spyOn(utils, "composeRenameString");
+    const newArgs: GenerateRenameListArgs = {
+      ...exampleArgs,
+      splitFileList: [splitFileList[0]],
+      separator: "|",
+      textPosition: "prepend",
+      truncate: "3",
+    };
+    addTextTransform(newArgs);
+    expect(spyOnCompose).toHaveBeenCalledTimes(1);
+    const call = spyOnCompose.mock.calls.flat()[0];
+    const expectations = [
+      ["baseName", splitFileList[0].baseName],
+      ["newName", newArgs.addText],
+      ["ext", splitFileList[0].ext],
+      ["separator", newArgs.separator],
+      ["textPosition", newArgs.textPosition],
+      ["truncate", newArgs.truncate],
+    ];
+    expectations.forEach((expectation) => {
+      const [key, value] = [expectation[0], expectation[1]];
+      expect(call[key as keyof typeof call]).toBe(value);
+    });
+  });
+});

--- a/src/tests/addTextTransform.spec.ts
+++ b/src/tests/addTextTransform.spec.ts
@@ -15,7 +15,6 @@ describe("addTextTransform", () => {
   it("Should return appropriately shaped response", () => {
     const renameList = addTextTransform(exampleArgs);
     expect(renameList.length).toBe(splitFileList.length);
-    const expectedKeys = ["rename", "original", "sourcePath"];
     const keys = Object.keys(renameList[0]);
     keys.forEach((key) => {
       expect(
@@ -23,36 +22,18 @@ describe("addTextTransform", () => {
       ).not.toBeUndefined();
     });
   });
+  it("Should call truncateFile, if appropriate", ()=> {
+    const spyOnTruncateFile = jest.spyOn(utils, "truncateFile");
+    const argsWithTruncate = {...exampleArgs, truncate: "5", splitFileList:[splitFileList[0]]};
+    const argsWithoutTruncate = {...argsWithTruncate, truncate: undefined};
+    [argsWithTruncate, argsWithoutTruncate].forEach(args =>addTextTransform(args));
+    expect(spyOnTruncateFile).toHaveBeenCalledTimes(1);
+  })
   it("Should addText to fileList", () => {
     const renameList = addTextTransform(exampleArgs);
     renameList.forEach((renameInstance) => {
       const { rename } = renameInstance;
       expect(rename).toContain(exampleArgs.addText);
-    });
-  });
-  it("Should call composeRenameString with appropriate arguments", () => {
-    const spyOnCompose = jest.spyOn(utils, "composeRenameString");
-    const newArgs: GenerateRenameListArgs = {
-      ...exampleArgs,
-      splitFileList: [splitFileList[0]],
-      separator: "|",
-      textPosition: "prepend",
-      truncate: "3",
-    };
-    addTextTransform(newArgs);
-    expect(spyOnCompose).toHaveBeenCalledTimes(1);
-    const call = spyOnCompose.mock.calls.flat()[0];
-    const expectations = [
-      ["baseName", splitFileList[0].baseName],
-      ["newName", newArgs.addText],
-      ["ext", splitFileList[0].ext],
-      ["separator", newArgs.separator],
-      ["textPosition", newArgs.textPosition],
-      ["truncate", newArgs.truncate],
-    ];
-    expectations.forEach((expectation) => {
-      const [key, value] = [expectation[0], expectation[1]];
-      expect(call[key as keyof typeof call]).toBe(value);
     });
   });
 });

--- a/src/tests/converter.spec.ts
+++ b/src/tests/converter.spec.ts
@@ -1,4 +1,5 @@
 import { writeFile } from "fs/promises";
+import * as addConverter from "../converters/addTextTransform.js";
 import * as converter from "../converters/converter.js";
 import * as dateTransformFunctions from "../converters/dateTransform.js";
 import * as numericTransformFunctions from "../converters/numericTransform.js";
@@ -6,11 +7,7 @@ import * as searchAndReplaceTransformFunctions from "../converters/searchAndRepl
 import * as truncateTransformFunctions from "../converters/truncateTransform.js";
 import * as utils from "../converters/utils.js";
 import { ERRORS } from "../messages/errMessages.js";
-import type {
-  DryRunTransformArgs,
-  RenameListArgs,
-  TransformTypes
-} from "../types.js";
+import type { DryRunTransformArgs, RenameListArgs, TransformTypes } from "../types.js";
 import {
   examplePath,
   exampleStats,
@@ -64,6 +61,7 @@ const spyOnGenerateRenameList = jest.spyOn(converter, "generateRenameList"),
     searchAndReplaceTransformFunctions,
     "searchAndReplace"
   ),
+  spyOnAddTextTransform = jest.spyOn(addConverter, "addTextTransform"),
   spyOnCreateBatchRename = jest
     .spyOn(utils, "createBatchRenameList")
     .mockReturnValue([Promise.resolve()]),
@@ -189,53 +187,28 @@ describe("convertFiles", () => {
   });
 });
 
-describe.skip("generateRenameList", () => {
+describe("generateRenameList", () => {
   afterEach(() => jest.clearAllMocks());
-  // Only valid transform combinations are evaluated. Invalid ones should be
-  // either be filtered out or throw an exception during
-  // the argument parsing phase.
-  it("Should call truncateTransform only if truncate is the single transform argument", () => {
-    generateRenameList({
-      transformPattern: ["truncate"],
-      splitFileList,
-    });
-    expect(spyOnTruncateTransform).toHaveBeenCalledTimes(1);
-    spyOnTruncateTransform.mockClear();
-    generateRenameList({
-      transformPattern: ["truncate", "dateRename"],
-      splitFileList,
-    });
-    expect(spyOnTruncateTransform).not.toHaveBeenCalled();
-  });
-  it("Should call dateRename, if it is included in transformPattern", () => {
-    const transforms: TransformTypes[][] = [
-      ["dateRename"],
-      ["dateRename", "truncate"],
-    ];
-    transforms.forEach((transformPattern, index) => {
-      generateRenameList({ transformPattern, splitFileList });
-      expect(spyOnDateTransform).toHaveBeenCalledTimes(index + 1);
-    });
-  });
-  it("Should call numericTransform, if it is included in transformPattern", () => {
-    const transforms: TransformTypes[][] = [
-      ["numericTransform"],
-      ["numericTransform", "truncate"],
-    ];
-    transforms.forEach((transformPattern, index) => {
-      generateRenameList({ transformPattern, splitFileList });
-      expect(spyOnNumericTransform).toHaveBeenCalledTimes(index + 1);
-    });
-  });
-  it("Should call searchAndReplace transform, if it is included in transformPattern", () => {
-    const transforms: TransformTypes[][] = [
-      ["searchAndReplace"],
-      ["searchAndReplace", "truncate"],
-    ];
-    transforms.forEach((transformPattern, index) => {
-      generateRenameList({ transformPattern, splitFileList });
-      expect(spyOnSearchAndReplace).toHaveBeenCalledTimes(index + 1);
-    });
+  it("Should call the first supplied transform type", () => {
+    const transformTypes = [
+      "truncate",
+      "dateRename",
+      "numericTransform",
+      "searchAndReplace",
+      "addText",
+    ] as const;
+    transformTypes.forEach((transformType) =>
+      generateRenameList({ transformPattern: [transformType], splitFileList })
+    );
+    [
+      spyOnDateTransform,
+      spyOnSearchAndReplace,
+      spyOnNumericTransform,
+      spyOnTruncateTransform,
+      spyOnAddTextTransform,
+    ].forEach((transformType) =>
+      expect(transformType).toHaveBeenCalledTimes(1)
+    );
   });
   it("Should throw error, if no transformation function is returned", () => {
     const transformPattern = ["invalidType"] as unknown as TransformTypes[];

--- a/src/tests/converter.spec.ts
+++ b/src/tests/converter.spec.ts
@@ -9,7 +9,7 @@ import { ERRORS } from "../messages/errMessages.js";
 import type {
   DryRunTransformArgs,
   RenameListArgs,
-  TransformTypes,
+  TransformTypes
 } from "../types.js";
 import {
   examplePath,
@@ -17,7 +17,7 @@ import {
   generateMockSplitFileList,
   mockFileList,
   renameListDistinct,
-  renameWithNewNameRepeat,
+  renameWithNewNameRepeat
 } from "./mocks.js";
 
 jest.mock("fs/promises", () => {
@@ -189,7 +189,7 @@ describe("convertFiles", () => {
   });
 });
 
-describe("generateRenameList", () => {
+describe.skip("generateRenameList", () => {
   afterEach(() => jest.clearAllMocks());
   // Only valid transform combinations are evaluated. Invalid ones should be
   // either be filtered out or throw an exception during

--- a/src/tests/dateTransform.spec.ts
+++ b/src/tests/dateTransform.spec.ts
@@ -3,13 +3,12 @@ import { stat } from "fs/promises";
 import { DEFAULT_SEPARATOR } from "../constants.js";
 import * as dateTransforms from "../converters/dateTransform.js";
 import * as utils from "../converters/utils.js";
-import { ERRORS } from "../messages/errMessages.js";
 import type {
-    ComposeRenameStringArgs,
-    DateTransformCorrespondenceTable,
-    FileListWithStatsArray,
-    FormattedDate,
-    GenerateRenameListArgs
+  ComposeRenameStringArgs,
+  DateTransformCorrespondenceTable,
+  FileListWithStatsArray,
+  FormattedDate,
+  GenerateRenameListArgs
 } from "../types.js";
 import { exampleStats as stats, generateMockSplitFileList } from "./mocks.js";
 
@@ -185,16 +184,6 @@ describe("dateTransform", () => {
         expected[key as keyof typeof expected]
       );
     });
-  });
-  it("Should check for name duplication", () => {
-    dateTransform(baseArgs);
-    expect(spyOnAreNewNamesDistinct).toHaveBeenCalledTimes(1);
-  });
-  it("Should throw error if duplicate names are found", () => {
-    spyOnAreNewNamesDistinct.mockClear().mockReturnValueOnce(false);
-    expect(() => dateTransform(baseArgs)).toThrowError(
-      ERRORS.DUPLICATE_FILE_NAMES
-    );
   });
   it("Should use separator in date formatting, unless it's of zero length", () => {
     spyOnExtractDate.mockReturnValue(extractDateExpected);

--- a/src/tests/dateTransform.spec.ts
+++ b/src/tests/dateTransform.spec.ts
@@ -5,11 +5,11 @@ import * as dateTransforms from "../converters/dateTransform.js";
 import * as utils from "../converters/utils.js";
 import { ERRORS } from "../messages/errMessages.js";
 import type {
-  ComposeRenameStringArgs,
-  DateTransformCorrespondenceTable,
-  FileListWithStatsArray,
-  FormattedDate,
-  GenerateRenameListArgs,
+    ComposeRenameStringArgs,
+    DateTransformCorrespondenceTable,
+    FileListWithStatsArray,
+    FormattedDate,
+    GenerateRenameListArgs
 } from "../types.js";
 import { exampleStats as stats, generateMockSplitFileList } from "./mocks.js";
 
@@ -165,7 +165,7 @@ describe("dateTransform", () => {
     const argsToWatch = {
       textPosition: "append" as const,
       preserveOriginal: false,
-      customText: "customText",
+      addText: "addText",
       separator: "|",
       truncate: "5",
     };

--- a/src/tests/numericTransform.spec.ts
+++ b/src/tests/numericTransform.spec.ts
@@ -33,7 +33,7 @@ const splitFileList = generateMockSplitFileList(10);
 
 const defaultArgs: GenerateRenameListArgs = {
   splitFileList,
-  customText: "customText",
+  addText: "addText",
   textPosition: undefined,
   preserveOriginal: true,
   numericTransform: "sequence",

--- a/src/tests/parseCommands.spec.ts
+++ b/src/tests/parseCommands.spec.ts
@@ -3,14 +3,14 @@ import program from "../commands/generateCommands.js";
 import * as parseCommands from "../commands/parseCommands.js";
 import {
   EXCLUSIVE_TRANSFORM_TYPES,
-  INCLUSIVE_TRANSFORM_TYPES,
+  INCLUSIVE_TRANSFORM_TYPES
 } from "../constants.js";
 import * as converters from "../converters/converter.js";
 import * as utils from "../converters/utils.js";
 import { ERRORS } from "../messages/errMessages.js";
 import type {
   OptionKeysWithValues,
-  OptionKeysWithValuesAndRestArgs,
+  OptionKeysWithValuesAndRestArgs
 } from "../types.js";
 import { examplePath } from "./mocks.js";
 
@@ -34,7 +34,7 @@ describe("parseOptions", () => {
   const spyOnConsoleError = jest.spyOn(console, "error");
   const exampleArgs = {
     preserveOriginal: true,
-    customText: false,
+    addText: false,
     numericTransform: true,
     folderPath: examplePath,
   } as OptionKeysWithValuesAndRestArgs;

--- a/src/tests/parseCommands.spec.ts
+++ b/src/tests/parseCommands.spec.ts
@@ -1,10 +1,6 @@
 import process from "process";
 import program from "../commands/generateCommands.js";
 import * as parseCommands from "../commands/parseCommands.js";
-import {
-  EXCLUSIVE_TRANSFORM_TYPES,
-  INCLUSIVE_TRANSFORM_TYPES
-} from "../constants.js";
 import * as converters from "../converters/converter.js";
 import * as utils from "../converters/utils.js";
 import { ERRORS } from "../messages/errMessages.js";
@@ -179,22 +175,12 @@ describe("setTransformationPath", () => {
 
 describe("transformationCheck", () => {
   const exampleArg = { preserveOriginal: true } as OptionKeysWithValues;
-  const inclusiveTypes: Partial<OptionKeysWithValues> = {};
-  const exclusiveTypes: Partial<OptionKeysWithValues> = {};
-  INCLUSIVE_TRANSFORM_TYPES.forEach((type) => (inclusiveTypes[type] = true));
-  EXCLUSIVE_TRANSFORM_TYPES.forEach((type) => (exclusiveTypes[type] = true));
-
   it("Should throw error if no transformation picked", () => {
     expect(() => transformationCheck(exampleArg)).toThrowError(
       ERRORS.COMMAND_NO_TRANSFORMATION_PICKED
     );
   });
-  it("Should throw error, if two exclusive transformation types are picked", () => {
-    expect(() =>
-      transformationCheck({ ...exampleArg, ...exclusiveTypes })
-    ).toThrowError(ERRORS.COMMAND_ONLY_ONE_EXCLUSIVE_TRANSFORM);
-  });
-  it("Should return a list of picked transformations", () => {
+  /* it("Should return a list of picked transformations", () => {
     const variants = [
       {
         [EXCLUSIVE_TRANSFORM_TYPES[0]]:
@@ -212,5 +198,5 @@ describe("transformationCheck", () => {
       const result = transformationCheck({ ...exampleArg, ...variant });
       expect(result).toEqual(expected);
     });
-  });
+  });*/
 });

--- a/src/tests/parseCommands.spec.ts
+++ b/src/tests/parseCommands.spec.ts
@@ -1,6 +1,7 @@
 import process from "process";
 import program from "../commands/generateCommands.js";
 import * as parseCommands from "../commands/parseCommands.js";
+import { VALID_TRANSFORM_TYPES } from "../constants.js";
 import * as converters from "../converters/converter.js";
 import * as utils from "../converters/utils.js";
 import { ERRORS } from "../messages/errMessages.js";
@@ -180,23 +181,18 @@ describe("transformationCheck", () => {
       ERRORS.COMMAND_NO_TRANSFORMATION_PICKED
     );
   });
-  /* it("Should return a list of picked transformations", () => {
+  it("Should return a list of picked transformations", () => {
     const variants = [
-      {
-        [EXCLUSIVE_TRANSFORM_TYPES[0]]:
-          exclusiveTypes[EXCLUSIVE_TRANSFORM_TYPES[0]]!,
-      },
-      {
-        [EXCLUSIVE_TRANSFORM_TYPES[0]]:
-          exclusiveTypes[EXCLUSIVE_TRANSFORM_TYPES[0]]!,
-        [INCLUSIVE_TRANSFORM_TYPES[0]]:
-          inclusiveTypes[INCLUSIVE_TRANSFORM_TYPES[0]]!,
-      },
+      { dateRename: true, truncate: true },
+      { addText: true, truncate: true, numericTransform: true },
+      { someOtherProp: true, numericTransform: true, anotherOther: true },
     ];
     variants.forEach((variant) => {
-      const expected = Object.keys(variant);
+      const expected = Object.keys(variant).filter((variant) =>
+        VALID_TRANSFORM_TYPES.some((transformType) => transformType === variant)
+      );
       const result = transformationCheck({ ...exampleArg, ...variant });
       expect(result).toEqual(expected);
     });
-  });*/
+  });
 });

--- a/src/tests/truncateTransform.spec.ts
+++ b/src/tests/truncateTransform.spec.ts
@@ -21,7 +21,7 @@ const defaultArgs: GenerateRenameListArgs = {
   splitFileList,
   transformPattern: ["truncate"],
   preserveOriginal: true,
-  customText: "customText",
+  addText: "addText",
   separator: DEFAULT_SEPARATOR,
   textPosition: undefined,
   truncate: "3",

--- a/src/tests/utils.spec.ts
+++ b/src/tests/utils.spec.ts
@@ -4,31 +4,31 @@ import { join, resolve } from "path";
 import process from "process";
 import { DEFAULT_SEPARATOR, ROLLBACK_FILE_NAME } from "../constants.js";
 import {
-  areNewNamesDistinct,
-  checkPath,
-  cleanUpRollbackFile,
-  composeRenameString,
-  createBatchRenameList,
-  determineDir,
-  extractBaseAndExt,
-  listFiles,
-  truncateFile,
+    areNewNamesDistinct,
+    checkPath,
+    cleanUpRollbackFile,
+    composeRenameString,
+    createBatchRenameList,
+    determineDir,
+    extractBaseAndExt,
+    listFiles,
+    truncateFile
 } from "../converters/utils.js";
 import { ERRORS } from "../messages/errMessages.js";
 import type {
-  ComposeRenameStringArgs,
-  ExtractBaseAndExtTemplate,
+    ComposeRenameStringArgs,
+    ExtractBaseAndExtTemplate
 } from "../types.js";
 import {
-  createDirentArray,
-  examplePath,
-  exampleStats,
-  expectedSplit,
-  mockFileList,
-  renameListDistinct,
-  renameListWithDuplicateOldAndNew,
-  renameWithNewNameRepeat,
-  truthyArgument,
+    createDirentArray,
+    examplePath,
+    exampleStats,
+    expectedSplit,
+    mockFileList,
+    renameListDistinct,
+    renameListWithDuplicateOldAndNew,
+    renameWithNewNameRepeat,
+    truthyArgument
 } from "./mocks.js";
 
 jest.mock("fs");
@@ -200,45 +200,45 @@ describe("determineDir", () => {
 });
 
 describe("composeRenameString", () => {
-  const [baseName, ext, customText, newName] = [
+  const [baseName, ext, addText, newName] = [
     "baseName",
     ".ext",
-    "customText",
+    "addText",
     "newName",
   ];
   const defaultSep = DEFAULT_SEPARATOR;
   const args: ComposeRenameStringArgs = {
     baseName,
     ext,
-    customText,
+    addText,
     newName,
     preserveOriginal: true,
   };
   it("Should return a newName-baseName.extension by default", () => {
     const expected = `${[newName, baseName].join(defaultSep)}${ext}`;
-    expect(composeRenameString({ ...args, customText: undefined })).toBe(
+    expect(composeRenameString({ ...args, addText: undefined })).toBe(
       expected
     );
   });
-  it("CustomText should override baseName and preserveOriginal", () => {
-    const expected = `${[newName, customText].join(defaultSep)}${ext}`;
+  it("addText should override baseName and preserveOriginal", () => {
+    const expected = `${[newName, addText].join(defaultSep)}${ext}`;
     expect(composeRenameString({ ...args, preserveOriginal: true })).toBe(
       expected
     );
   });
-  it("Should drop original baseName, if preserveOriginal is false|undefined and no customText supplied", () => {
+  it("Should drop original baseName, if preserveOriginal is false|undefined and no addText supplied", () => {
     const expected = `${newName}${ext}`;
     expect(
       composeRenameString({
         ...args,
-        customText: undefined,
+        addText: undefined,
         preserveOriginal: undefined,
       })
     ).toBe(expected);
     expect(
       composeRenameString({
         ...args,
-        customText: undefined,
+        addText: undefined,
         preserveOriginal: false,
       })
     ).toBe(expected);
@@ -246,22 +246,22 @@ describe("composeRenameString", () => {
   it("Should return newName-baseName only, if extension is undefined", () => {
     const expected = `${newName}${defaultSep}${baseName}`;
     expect(
-      composeRenameString({ ...args, customText: undefined, ext: undefined })
+      composeRenameString({ ...args, addText: undefined, ext: undefined })
     ).toBe(expected);
   });
   it("Should respect textPosition", () => {
-    let expected = `${[customText, newName].join(defaultSep)}${ext}`;
+    let expected = `${[addText, newName].join(defaultSep)}${ext}`;
     expect(composeRenameString({ ...args, textPosition: "prepend" })).toBe(
       expected
     );
-    expected = `${[newName, customText].join(defaultSep)}${ext}`;
+    expected = `${[newName, addText].join(defaultSep)}${ext}`;
     expect(composeRenameString({ ...args, textPosition: "append" })).toBe(
       expected
     );
   });
   it("Should respect separator setting", () => {
     const newSep = "_";
-    const expected = `${[newName, customText].join(newSep)}${ext}`;
+    const expected = `${[newName, addText].join(newSep)}${ext}`;
     expect(composeRenameString({ ...args, separator: newSep })).toBe(expected);
   });
   it("Should truncate result if truncate argument is truthy and preserveOriginal is true", () => {
@@ -269,7 +269,7 @@ describe("composeRenameString", () => {
     const newArgs = {
       ...args,
       truncate: "4",
-      customText: "",
+      addText: "",
       separator: "",
       newName: "",
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import {
   UTILITY_ACTIONS,
   VALID_DATE_TRANSFORM_TYPES,
   VALID_NUMERIC_TRANSFORM_TYPES,
-  VALID_TRANSFORM_TYPES,
+  VALID_TRANSFORM_TYPES
 } from "./constants";
 
 export type OptionKeys =
@@ -12,7 +12,7 @@ export type OptionKeys =
   | "restore"
   | "dryRun"
   | "cleanRollback"
-  | "customText"
+  | "addText"
   | "dateRename"
   | "textPosition"
   | "searchAndReplace"
@@ -77,7 +77,7 @@ export type RenameList = {
 }[];
 export type RenameListArgs = {
   transformPattern: TransformTypes[];
-  customText?: string;
+  addText?: string;
   textPosition?: "append" | "prepend";
   preserveOriginal?: boolean;
   noExtensionPreserve?: boolean;
@@ -144,6 +144,8 @@ export type TruncateFileNameArgs = {
 export type TruncateFileName = (args: TruncateFileNameArgs) => string;
 export type TruncateTransform = (args: GenerateRenameListArgs) => RenameList;
 
+export type AddTextTransform = (args: GenerateRenameListArgs) => RenameList;
+
 export type ProgramOptions = {
   short: string;
   long: OptionKeys;
@@ -193,7 +195,7 @@ export type ComposeRenameStringArgs = {
   newName: string;
   ext?: string;
   preserveOriginal?: boolean;
-  customText?: string;
+  addText?: string;
   textPosition?: "prepend" | "append";
   separator?: string;
   truncate?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -187,7 +187,9 @@ export type ListFiles = (
   transformPath?: string,
   excludeFilter?: string
 ) => Promise<string[]>;
-export type AreNewNamesDistinct = (renameLIst: RenameList) => boolean;
+export type AreNewNamesDistinct = (renameList: RenameList) => boolean;
+export type NumberOfDuplicatedNamesArgs = {renameList: RenameList, checkType: "results"|"transforms"};
+export type NumberOfDuplicatedNames = (args: NumberOfDuplicatedNamesArgs) => number;
 export type CheckPath = (path: string) => Promise<string>;
 export type DetermineDir = (transformPath: string | undefined) => string;
 export type ComposeRenameStringArgs = {


### PR DESCRIPTION
-addText transform added (addText option now replaces customText which was used before).
- Removed distinction between inclusive and exclusive transformation.
- added numberOfDuplicatedNames function and made areNewNamesDistinct rely on it.
- Updated converter logic (transforms are now called via a correspondence table instead of a list of if statements) and dryRun implementation (more detailed reports).
- Updated tests.
- Other optiimzations.