### PR TITLE
Feature/write-error-handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The script will not perform a rename if it would lead to name collisions (i.e. s
 |`-e, --extensionModify`|`<string>`|Modify extension of target files. Can also be used together with the exclude option|
 |`-a, --addText`|`<string>`|Text to add to the target filename. Can be used on its own, together with 'textPosition' flag, or in combination with other transform types. Overwrites the `preserveOriginal` flag.|
 |`--target`|`<path>`|Folder in which the transformation should take place. *Can also be set implicitly* with an extra script argument (explicit setting takes precedence). If omitted, the script defaults to current working directory.|
-|`--targetType`|`['files'\|'dirs'\|'all']`||`Determine which file types should be included in transform. Defaults to 'files' If omitted or supplied without option.`
+|`--targetType`|`['files'\|'dirs'\|'all']`|Determine which file types should be included in transform. Defaults to 'files' If omitted or supplied without option.|
 |`-r, --restore`||Restore transformed files to original names, if restore file is available.|
 |`-D, --dryRun`||Run transform operation without writing to disk. Will log properties of expected output. Prompts user for transform execution, if no errors detected.|
 |`-b, --baseIndex`|`<number>`|For numeric transform, optional argument to specify the base index from which the sequencing will begin|

--- a/src/converters/converter.ts
+++ b/src/converters/converter.ts
@@ -31,7 +31,7 @@ import {
   extractBaseAndExt,
   listFiles,
   numberOfDuplicatedNames,
-  pruneTransformedNamesList,
+  settledPromisesEval,
 } from "./utils.js";
 const { duplicateRenames, noTransformFunctionAvailable } = ERRORS.transforms;
 const {
@@ -96,10 +96,12 @@ export const convertFiles = async (args: RenameListArgs): Promise<void> => {
   const batchRename = createBatchRenameList(transformedNames);
   console.log(`Renaming ${batchRename.length} files...`);
   const promiseResults = await Promise.allSettled(batchRename);
-  const updatedRenameList = pruneTransformedNamesList({
+  const updatedRenameList = settledPromisesEval({
     promiseResults,
     transformedNames,
+    operationType: "convert",
   });
+
   console.log("Rename completed!");
   process.stdout.write("Writing rollback file...");
   await writeFile(

--- a/src/converters/converter.ts
+++ b/src/converters/converter.ts
@@ -3,7 +3,7 @@ import { resolve } from "path";
 import {
   ROLLBACK_FILE_NAME,
   VALID_DRY_RUN_ANSWERS,
-  VALID_TRANSFORM_TYPES
+  VALID_TRANSFORM_TYPES,
 } from "../constants.js";
 import { ERRORS } from "../messages/errMessages.js";
 import { STATUS } from "../messages/statusMessages.js";
@@ -13,7 +13,7 @@ import type {
   FileListWithStatsArray,
   GenerateRenameList,
   GenerateRenameListArgs,
-  RenameListArgs
+  RenameListArgs,
 } from "../types";
 import { addTextTransform } from "./addTextTransform.js";
 import { dateTransform, provideFileStats } from "./dateTransform.js";
@@ -30,7 +30,8 @@ import {
   determineDir,
   extractBaseAndExt,
   listFiles,
-  numberOfDuplicatedNames
+  numberOfDuplicatedNames,
+  pruneTransformedNamesList,
 } from "./utils.js";
 const { duplicateRenames, noTransformFunctionAvailable } = ERRORS.transforms;
 const {
@@ -50,7 +51,7 @@ export const TRANSFORM_CORRESPONDENCE_TABLE: Record<
   dateRename: (args: GenerateRenameListArgs) => dateTransform(args),
   numericTransform: (args: GenerateRenameListArgs) => numericTransform(args),
   searchAndReplace: (args: GenerateRenameListArgs) => searchAndReplace(args),
-  keep: (args:GenerateRenameListArgs) => keepTransform(args),
+  keep: (args: GenerateRenameListArgs) => keepTransform(args),
   truncate: (args: GenerateRenameListArgs) => truncateTransform(args),
   extensionModify: (args: GenerateRenameListArgs) =>
     extensionModifyTransform(args),
@@ -92,17 +93,21 @@ export const convertFiles = async (args: RenameListArgs): Promise<void> => {
   const newNamesDistinct = areNewNamesDistinct(transformedNames);
   if (!newNamesDistinct) throw new Error(duplicateRenames);
 
+  const batchRename = createBatchRenameList(transformedNames);
+  console.log(`Renaming ${batchRename.length} files...`);
+  const promiseResults = await Promise.allSettled(batchRename);
+  const updatedRenameList = pruneTransformedNamesList({
+    promiseResults,
+    transformedNames,
+  });
+  console.log("Rename completed!");
   process.stdout.write("Writing rollback file...");
   await writeFile(
     resolve(targetDir, ROLLBACK_FILE_NAME),
-    JSON.stringify(transformedNames, undefined, 2),
+    JSON.stringify(updatedRenameList, undefined, 2),
     "utf-8"
   );
   process.stdout.write("DONE.\n");
-  const batchRename = createBatchRenameList(transformedNames);
-  console.log(`Renaming ${batchRename.length} files...`);
-  await Promise.all(batchRename);
-  console.log("Completed!");
 };
 
 export const generateRenameList: GenerateRenameList = (args) => {

--- a/src/converters/keepTransform.ts
+++ b/src/converters/keepTransform.ts
@@ -7,7 +7,7 @@ export const keepTransform: KeepTransform = ({
   textPosition,
   separator,
   /**Current limitation: format option will never format the extension, as
-   * the extension will be removed if  noExtensionPreserve is true.
+   * the extension will be removed if noExtensionPreserve is true.
    */
   format,
   splitFileList,

--- a/src/converters/restorePoint.ts
+++ b/src/converters/restorePoint.ts
@@ -8,14 +8,15 @@ import type {
   DryRunRestore,
   RenameList,
   RestoreBaseFunction,
-  RestoreOriginalFileNames
+  RestoreOriginalFileNames,
 } from "../types";
 import {
   askQuestion,
   cleanUpRollbackFile,
   createBatchRenameList,
   determineDir,
-  listFiles
+  listFiles,
+  settledPromisesEval,
 } from "./utils.js";
 
 const { couldNotBeParsed, noFilesToConvert, noRollbackFile, noValidData } =
@@ -74,7 +75,8 @@ export const restoreOriginalFileNames: RestoreOriginalFileNames = async ({
   }
   const { rollbackData, filesToRestore } = restoreBaseData;
 
-  let batchRename: Promise<void>[] = [];
+  let batchRename: Promise<void>[] = [],
+    updatedRenameList: RenameList = [];
   if (filesToRestore.length) {
     batchRename = createBatchRenameList(rollbackData, filesToRestore);
   }
@@ -82,9 +84,19 @@ export const restoreOriginalFileNames: RestoreOriginalFileNames = async ({
     throw new Error(couldNotBeParsed);
   }
   if (batchRename.length) {
+    updatedRenameList = rollbackData.filter(({ rename }) =>
+      filesToRestore.includes(rename)
+    );
     const revertMessage = `Will revert ${batchRename.length} files...`;
     console.log(revertMessage);
-    await Promise.all(batchRename);
+    const promiseResults = await Promise.allSettled(batchRename);
+
+    settledPromisesEval({
+      promiseResults,
+      transformedNames: updatedRenameList,
+      operationType: "restore",
+    });
+
     await cleanUpRollbackFile({ transformPath });
   }
 };

--- a/src/converters/restorePoint.ts
+++ b/src/converters/restorePoint.ts
@@ -87,8 +87,8 @@ export const restoreOriginalFileNames: RestoreOriginalFileNames = async ({
     updatedRenameList = rollbackData.filter(({ rename }) =>
       filesToRestore.includes(rename)
     );
-    const revertMessage = `Will revert ${batchRename.length} files...`;
-    console.log(revertMessage);
+
+    console.log(`Will revert ${batchRename.length} files...`);
     const promiseResults = await Promise.allSettled(batchRename);
 
     settledPromisesEval({

--- a/src/converters/searchAndReplace.ts
+++ b/src/converters/searchAndReplace.ts
@@ -1,7 +1,7 @@
 import { Dirent } from "fs";
 import type {
   GenerateSearchAndReplaceArgs,
-  SearchAndReplace
+  SearchAndReplace,
 } from "../types.js";
 import { formatFile } from "./formatTextTransform.js";
 import { extractBaseAndExt, truncateFile } from "./utils.js";
@@ -13,7 +13,7 @@ export const searchAndReplace: SearchAndReplace = ({
   truncate,
   format,
 }) => {
-  const generatedArgs = generateArguments(searchAndReplace!);
+  const generatedArgs = generateSearchAndReplaceArgs(searchAndReplace!);
   const targetList = splitFileList.map((fileInfo) => {
     const { filter, replace } = generatedArgs;
     let { baseName, sourcePath, ext, type } = fileInfo;
@@ -40,7 +40,9 @@ export const searchAndReplace: SearchAndReplace = ({
   return targetList;
 };
 
-export const generateArguments: GenerateSearchAndReplaceArgs = (args) => {
+export const generateSearchAndReplaceArgs: GenerateSearchAndReplaceArgs = (
+  args
+) => {
   if (args.length === 1) return { filter: null, replace: args[0] };
   return { filter: new RegExp(args[0], "gu"), replace: args[1] };
 };

--- a/src/messages/errMessages.ts
+++ b/src/messages/errMessages.ts
@@ -19,6 +19,7 @@ export const ERRORS = {
     noChildFiles:
       "Directory has no children file entries ('files' target type)",
     noChildDirs: "Directory has no child sub-directories ('dirs' target type)",
+    allRenameFailed: "All rename operations failed! No file has been changed.",
   },
   transforms: {
     noTransformFunctionAvailable: `No transform function available for the chosen option!`,
@@ -31,7 +32,6 @@ export const ERRORS = {
     noTransformationPicked: `No transformation operation picked! Please specify one of the following: ${VALID_TRANSFORM_TYPES.join(
       ", "
     )}`,
-
     duplicateRenames:
       "Transformation would lead to duplication of file names! Operation aborted.",
   },

--- a/src/messages/statusMessages.ts
+++ b/src/messages/statusMessages.ts
@@ -1,7 +1,9 @@
 export const STATUS = {
   dryRun: {
     transformIntro(transformPattern: string[], transformPath: string): string {
-      return `Transformations of type ${transformPattern.join(", ")} in folder ${transformPath} would result in the following transform:`;
+      return `Transformations of type ${transformPattern.join(
+        ", "
+      )} in folder ${transformPath} would result in the following transform:`;
     },
     warningUnaffectedFiles(unaffectedFiles: number) {
       return `Number of files for which transform has no effect: ${unaffectedFiles}`;
@@ -25,5 +27,22 @@ export const STATUS = {
     questionPerformRestore:
       "Would you like to execute the restore of original entry names (N/Y)?",
     exitWithoutRestore: "Exited application without performing restore.",
+  },
+  settledPromisesEval: {
+    failReport: (
+      promisesRejected: number,
+      operationType: "convert" | "restore"
+    ) => `${promisesRejected} ${operationType} operations were unsuccessful:`,
+    failItem: (
+      original: string,
+      rename: string,
+      operationType: "convert" | "restore"
+    ) => {
+      const renameOrder =
+        operationType === "convert"
+          ? `${original} => ${rename}`
+          : `${rename} => ${original}`;
+      return `${operationType}: ${renameOrder}`;
+    },
   },
 };

--- a/src/tests/converter.spec.ts
+++ b/src/tests/converter.spec.ts
@@ -212,6 +212,28 @@ describe("convertFiles", () => {
     expect(spyOnPromiseAllSettled).toHaveBeenCalledWith(mockBatchPromises);
     spyOnPromiseAllSettled.mockRestore();
   });
+  it("Should call settledPromisesEval with appropriate arguments", async () => {
+    const mockBatchPromises = [...renameListDistinct].map(() =>
+      Promise.resolve()
+    );
+    spyOnGenerateRenameList.mockImplementationOnce(() => renameListDistinct);
+    mockBatchPromises[0] = Promise.reject();
+    spyOnCreateBatchRename.mockReturnValueOnce(mockBatchPromises);
+    const promiseResults = await Promise.allSettled(mockBatchPromises);
+    const spyOnSettledPromisesEval = jest.spyOn(utils, "settledPromisesEval");
+    await convertFiles(exampleArgs);
+    spyOnProcessWrite.mockRestore();
+    spyOnConsole.mockRestore();
+    expect(spyOnSettledPromisesEval).toHaveBeenCalledTimes(1);
+    expect(spyOnSettledPromisesEval).toHaveBeenCalledWith({
+      promiseResults,
+      transformedNames: renameListDistinct,
+      operationType: "convert",
+    });
+    expect(spyOnSettledPromisesEval).toHaveReturnedWith(
+      renameListDistinct.slice(1)
+    );
+  });
   it("Should call console.log twice", async () => {
     await convertFiles(exampleArgs);
     expect(spyOnConsole).toHaveBeenCalledTimes(2);

--- a/src/tests/converter.spec.ts
+++ b/src/tests/converter.spec.ts
@@ -11,14 +11,14 @@ import type {
   DryRunTransformArgs,
   RenameList,
   RenameListArgs,
-  TransformTypes
+  TransformTypes,
 } from "../types.js";
 import {
   examplePath,
   exampleStats,
   generateMockSplitFileList,
   mockFileList,
-  renameListDistinct
+  renameListDistinct,
 } from "./mocks.js";
 
 jest.mock("fs/promises", () => {
@@ -140,13 +140,17 @@ describe("convertFiles", () => {
   it("Should continue execution, if dryRunTransform returns true", async () => {
     spyOnAreNewNamesDistinct.mockClear();
     spyOnAreNewNamesDistinct.mockReturnValueOnce(true);
-    spyOnDryRunTransform.mockImplementationOnce((args)=> Promise.resolve(true));
-    await convertFiles({...exampleArgs, dryRun: true});
+    spyOnDryRunTransform.mockImplementationOnce((args) =>
+      Promise.resolve(true)
+    );
+    await convertFiles({ ...exampleArgs, dryRun: true });
     expect(spyOnAreNewNamesDistinct).toHaveBeenCalledTimes(1);
-    
+
     spyOnAreNewNamesDistinct.mockClear();
-    spyOnDryRunTransform.mockImplementationOnce((args)=> Promise.resolve(false));
-    await convertFiles({...exampleArgs, dryRun: true});
+    spyOnDryRunTransform.mockImplementationOnce((args) =>
+      Promise.resolve(false)
+    );
+    await convertFiles({ ...exampleArgs, dryRun: true });
     expect(spyOnAreNewNamesDistinct).not.toHaveBeenCalled();
   });
   it("Should include exclude argument in listFiles, if provided", async () => {
@@ -157,10 +161,14 @@ describe("convertFiles", () => {
     expect(spyOnListFiles).toHaveBeenLastCalledWith(
       examplePath,
       exampleArgs.exclude,
-      undefined,
+      undefined
     );
     await convertFiles({ ...exampleArgs, exclude: undefined });
-    expect(spyOnListFiles).toHaveBeenLastCalledWith(examplePath, undefined, undefined);
+    expect(spyOnListFiles).toHaveBeenLastCalledWith(
+      examplePath,
+      undefined,
+      undefined
+    );
   });
   it("Should run provideFileStats with dateTransform", async () => {
     await convertFiles(exampleArgs);
@@ -198,11 +206,11 @@ describe("convertFiles", () => {
     const mockBatchPromises = [0, 1, 2, 3].map((num) => Promise.resolve());
     spyOnCreateBatchRename.mockReturnValueOnce(mockBatchPromises);
 
-    const spyOnPromiseAll = jest.spyOn(Promise, "all");
+    const spyOnPromiseAllSettled = jest.spyOn(Promise, "allSettled");
     await convertFiles(exampleArgs);
-    expect(spyOnPromiseAll).toHaveBeenCalledTimes(1);
-    expect(spyOnPromiseAll).toHaveBeenCalledWith(mockBatchPromises);
-    spyOnPromiseAll.mockRestore();
+    expect(spyOnPromiseAllSettled).toHaveBeenCalledTimes(1);
+    expect(spyOnPromiseAllSettled).toHaveBeenCalledWith(mockBatchPromises);
+    spyOnPromiseAllSettled.mockRestore();
   });
   it("Should call console.log twice", async () => {
     await convertFiles(exampleArgs);

--- a/src/tests/searchAndReplace.spec.ts
+++ b/src/tests/searchAndReplace.spec.ts
@@ -5,22 +5,25 @@ import { GenerateRenameListArgs } from "../types.js";
 import {
   generateMockSplitFileList,
   mockDirentEntryAsFile,
-  mockSplitFile
+  mockSplitFile,
 } from "./mocks.js";
 
 const { extractBaseAndExt } = utils;
 
-const { generateArguments, optionalTruncate, searchAndReplace } =
+const { generateSearchAndReplaceArgs, optionalTruncate, searchAndReplace } =
   regexTransform;
-const spyOnGenerateArguments = jest.spyOn(regexTransform, "generateArguments"),
+const spyOnGenerateArguments = jest.spyOn(
+    regexTransform,
+    "generateSearchAndReplaceArgs"
+  ),
   spyOnOptionalTruncate = jest.spyOn(regexTransform, "optionalTruncate"),
   spyOnExtractBaseAndExt = jest.spyOn(utils, "extractBaseAndExt"),
   spyOnTruncateFile = jest.spyOn(utils, "truncateFile");
 
-describe("generateArguments", () => {
+describe("generateSearchAndReplaceArgs", () => {
   const exampleArgs = ["filter", "replace"];
   it("Should return proper shape of object", () => {
-    const replaceConfig = generateArguments(exampleArgs);
+    const replaceConfig = generateSearchAndReplaceArgs(exampleArgs);
     Object.entries(replaceConfig).forEach((entry, index) => {
       const [key, value] = [entry[0], entry[1]];
       expect(key).toBe(exampleArgs[index]);
@@ -30,15 +33,15 @@ describe("generateArguments", () => {
     });
   });
   it("Filter should be null, if only one argument is supplied", () => {
-    const replaceConfig = generateArguments([exampleArgs[0]]);
+    const replaceConfig = generateSearchAndReplaceArgs([exampleArgs[0]]);
     expect(replaceConfig.filter).toBeNull();
   });
   it("Filter should include passed string", () => {
-    const replaceConfig = generateArguments(exampleArgs);
+    const replaceConfig = generateSearchAndReplaceArgs(exampleArgs);
     expect(replaceConfig.filter!.source).toBe(exampleArgs[0]);
   });
   it("Filter should have only global flag set", () => {
-    const replaceConfig = generateArguments(exampleArgs);
+    const replaceConfig = generateSearchAndReplaceArgs(exampleArgs);
     expect(replaceConfig.filter!.flags).toBe("gu");
   });
 });

--- a/src/tests/utils.spec.ts
+++ b/src/tests/utils.spec.ts
@@ -14,7 +14,7 @@ import {
   extractBaseAndExt,
   listFiles,
   numberOfDuplicatedNames,
-  pruneTransformedNamesList,
+  settledPromisesEval,
   truncateFile,
 } from "../converters/utils.js";
 import { ERRORS } from "../messages/errMessages.js";
@@ -521,8 +521,11 @@ describe("createBatchRenameList", () => {
   });
 });
 
-describe.only("pruneTransformedList", () => {
-  const args = { transformedNames: renameListDistinct },
+describe("settledPromisesEval", () => {
+  const args = {
+      transformedNames: renameListDistinct,
+      operationType: "convert" as const,
+    },
     settledLength = renameListDistinct.length,
     rejected = {
       status: "rejected",
@@ -536,7 +539,7 @@ describe.only("pruneTransformedList", () => {
     const promiseResults = new Array(settledLength).fill(
       fulfilled
     ) as PromiseSettledResult<void>[];
-    const result = pruneTransformedNamesList({ ...args, promiseResults });
+    const result = settledPromisesEval({ ...args, promiseResults });
     expect(result).toEqual(args.transformedNames);
   });
   it("Should throw error, if all promises are rejected", () => {
@@ -544,9 +547,9 @@ describe.only("pruneTransformedList", () => {
       rejected
     ) as PromiseSettledResult<void>[];
 
-    expect(() =>
-      pruneTransformedNamesList({ ...args, promiseResults })
-    ).toThrowError(ERRORS.utils.allRenameFailed);
+    expect(() => settledPromisesEval({ ...args, promiseResults })).toThrowError(
+      ERRORS.utils.allRenameFailed
+    );
   });
   it("Should remove entries that resulted in rejected promises", () => {
     const promiseResults: PromiseSettledResult<void>[] = [
@@ -554,7 +557,7 @@ describe.only("pruneTransformedList", () => {
       fulfilled,
       rejected,
     ];
-    const result = pruneTransformedNamesList({ ...args, promiseResults });
+    const result = settledPromisesEval({ ...args, promiseResults });
     expect(result.length).toBe(renameListDistinct.length - 2);
 
     const rejectedNames = [

--- a/src/tests/utils.spec.ts
+++ b/src/tests/utils.spec.ts
@@ -14,13 +14,14 @@ import {
   extractBaseAndExt,
   listFiles,
   numberOfDuplicatedNames,
-  truncateFile
+  pruneTransformedNamesList,
+  truncateFile,
 } from "../converters/utils.js";
 import { ERRORS } from "../messages/errMessages.js";
 import type {
   ComposeRenameStringArgs,
   ExtractBaseAndExtTemplate,
-  ValidTypes
+  ValidTypes,
 } from "../types.js";
 import {
   createDirentArray,
@@ -31,7 +32,7 @@ import {
   renameListDistinct,
   renameListWithDuplicateOldAndNew,
   renameWithNewNameRepeat,
-  truthyArgument
+  truthyArgument,
 } from "./mocks.js";
 
 const {
@@ -517,6 +518,54 @@ describe("createBatchRenameList", () => {
       );
       expect(batchPromise.length).toBe(expectedLength);
     });
+  });
+});
+
+describe.only("pruneTransformedList", () => {
+  const args = { transformedNames: renameListDistinct },
+    settledLength = renameListDistinct.length,
+    rejected = {
+      status: "rejected",
+      reason: "someReason",
+    } as const,
+    fulfilled = {
+      status: "fulfilled",
+      value: void 0,
+    } as const;
+  it("Should return unmodified rename list, if all promises are fulfilled", () => {
+    const promiseResults = new Array(settledLength).fill(
+      fulfilled
+    ) as PromiseSettledResult<void>[];
+    const result = pruneTransformedNamesList({ ...args, promiseResults });
+    expect(result).toEqual(args.transformedNames);
+  });
+  it("Should throw error, if all promises are rejected", () => {
+    const promiseResults = new Array(settledLength).fill(
+      rejected
+    ) as PromiseSettledResult<void>[];
+
+    expect(() =>
+      pruneTransformedNamesList({ ...args, promiseResults })
+    ).toThrowError(ERRORS.utils.allRenameFailed);
+  });
+  it("Should remove entries that resulted in rejected promises", () => {
+    const promiseResults: PromiseSettledResult<void>[] = [
+      rejected,
+      fulfilled,
+      rejected,
+    ];
+    const result = pruneTransformedNamesList({ ...args, promiseResults });
+    expect(result.length).toBe(renameListDistinct.length - 2);
+
+    const rejectedNames = [
+      renameListDistinct[0].original,
+      renameListDistinct[2].original,
+    ];
+    const areRejectedPresent = result.some(({ original }) =>
+      rejectedNames.includes(original)
+    );
+
+    expect(areRejectedPresent).toBe(false);
   });
 });
 

--- a/src/tests/utils.spec.ts
+++ b/src/tests/utils.spec.ts
@@ -18,6 +18,7 @@ import {
   truncateFile,
 } from "../converters/utils.js";
 import { ERRORS } from "../messages/errMessages.js";
+import { STATUS } from "../messages/statusMessages.js";
 import type {
   ComposeRenameStringArgs,
   ExtractBaseAndExtTemplate,
@@ -569,6 +570,30 @@ describe("settledPromisesEval", () => {
     );
 
     expect(areRejectedPresent).toBe(false);
+  });
+  it("Should produce appropriate failReport and failItem messages", () => {
+    const promiseResults: PromiseSettledResult<void>[] = [
+      fulfilled,
+      fulfilled,
+      rejected,
+    ];
+    for (const operationType of ["convert", "restore"] as const) {
+      const { failReport, failItem } = STATUS.settledPromisesEval;
+      const spyOnConsole = jest.spyOn(console, "log");
+      settledPromisesEval({ ...args, operationType, promiseResults });
+
+      const expectedFailReport = failReport(1, operationType);
+      const expectedFailItem = failItem(
+        renameListDistinct[2].original,
+        renameListDistinct[2].rename,
+        operationType
+      );
+
+      expect(spyOnConsole).toHaveBeenCalledTimes(2);
+      expect(spyOnConsole).toHaveBeenNthCalledWith(1, expectedFailReport);
+      expect(spyOnConsole).toHaveBeenNthCalledWith(2, expectedFailItem);
+      spyOnConsole.mockRestore();
+    }
   });
 });
 

--- a/src/tests/utils.spec.ts
+++ b/src/tests/utils.spec.ts
@@ -523,6 +523,14 @@ describe("createBatchRenameList", () => {
 });
 
 describe("settledPromisesEval", () => {
+  let spyOnConsole: jest.SpyInstance;
+  beforeEach(
+    () =>
+      (spyOnConsole = jest
+        .spyOn(console, "log")
+        .mockImplementation((message?: string) => {}))
+  );
+  afterEach(() => spyOnConsole.mockRestore());
   const args = {
       transformedNames: renameListDistinct,
       operationType: "convert" as const,
@@ -579,7 +587,6 @@ describe("settledPromisesEval", () => {
     ];
     for (const operationType of ["convert", "restore"] as const) {
       const { failReport, failItem } = STATUS.settledPromisesEval;
-      const spyOnConsole = jest.spyOn(console, "log");
       settledPromisesEval({ ...args, operationType, promiseResults });
 
       const expectedFailReport = failReport(1, operationType);
@@ -592,7 +599,7 @@ describe("settledPromisesEval", () => {
       expect(spyOnConsole).toHaveBeenCalledTimes(2);
       expect(spyOnConsole).toHaveBeenNthCalledWith(1, expectedFailReport);
       expect(spyOnConsole).toHaveBeenNthCalledWith(2, expectedFailItem);
-      spyOnConsole.mockRestore();
+      spyOnConsole.mockClear();
     }
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import {
   UTILITY_ACTIONS,
   VALID_DATE_TRANSFORM_TYPES,
   VALID_NUMERIC_TRANSFORM_TYPES,
-  VALID_TRANSFORM_TYPES
+  VALID_TRANSFORM_TYPES,
 } from "./constants";
 
 export type ValidTypes = "files" | "dirs" | "all";


### PR DESCRIPTION
Conversion and restore operations will now check if the writes were successful. 

If a write is unsuccessful for the convert operation, the entry will be removed from the rollback file and print warnings to the console.

If a write is unusccessful for the restore operation, the function will print warnings to the console.
