### PR TITLE
Failed restores and conversions handling fixes

### DIFF
--- a/src/converters/converter.ts
+++ b/src/converters/converter.ts
@@ -112,14 +112,14 @@ export const convertFiles = async (args: RenameListArgs): Promise<void> => {
   const batchRename = createBatchRenameList(transforms);
   console.log(`Renaming ${batchRename.length} files...`);
   const promiseResults = await Promise.allSettled(batchRename);
-  const updatedRenameList = settledPromisesEval({
+  const updatedBaseRenameList = settledPromisesEval({
     promiseResults,
     transformedNames: transforms.transforms,
     operationType: "convert",
-  });
+  }).successful;
 
   const createdRollback = await createRollback({
-    transforms: updatedRenameList,
+    transforms: updatedBaseRenameList,
     sourcePath: targetDir,
   });
   console.log("Rename completed!");

--- a/src/converters/restorePoint.ts
+++ b/src/converters/restorePoint.ts
@@ -103,7 +103,7 @@ export const restoreOriginalFileNames: RestoreOriginalFileNames = async ({
     console.log(`Will revert ${batchRename.length} files...`);
     const promiseResults = await Promise.allSettled(batchRename);
 
-    settledPromisesEval({
+   const {successful, failed}= settledPromisesEval({
       promiseResults,
       transformedNames: updatedRenameList,
       operationType: "restore",

--- a/src/tests/converter.spec.ts
+++ b/src/tests/converter.spec.ts
@@ -234,7 +234,7 @@ describe("convertFiles", () => {
       Promise.resolve()
     );
     mockBatchPromises[0] = Promise.reject(
-      generateRejected(mockDistinctList[0]).reason
+      generateRejected(mockDistinctList[0], "convert").reason
     );
     spyOnCreateBatchRename.mockReturnValueOnce(mockBatchPromises);
     const promiseResults = await Promise.allSettled(mockBatchPromises);

--- a/src/tests/converter.spec.ts
+++ b/src/tests/converter.spec.ts
@@ -19,6 +19,7 @@ import {
   examplePath,
   exampleStats,
   generateMockSplitFileList,
+  generateRejected,
   mockFileList,
   mockRenameListToolSet
 } from "./mocks.js";
@@ -32,6 +33,7 @@ const splitFileListWithStats = splitFileList.map((fileList) => ({
   stats: exampleStats,
 }));
 const { convertFiles, dryRunTransform, generateRenameList } = converter;
+const { settledPromisesEval } = utils;
 
 // SPIES AND MOCKS SETUP
 jest.mock("fs/promises", () => {
@@ -231,7 +233,9 @@ describe("convertFiles", () => {
     const mockBatchPromises = [...mockDistinctList].map(() =>
       Promise.resolve()
     );
-    mockBatchPromises[0] = Promise.reject();
+    mockBatchPromises[0] = Promise.reject(
+      generateRejected(mockDistinctList[0]).reason
+    );
     spyOnCreateBatchRename.mockReturnValueOnce(mockBatchPromises);
     const promiseResults = await Promise.allSettled(mockBatchPromises);
     const spyOnSettledPromisesEval = jest.spyOn(utils, "settledPromisesEval");
@@ -244,9 +248,11 @@ describe("convertFiles", () => {
       transformedNames: mockDistinctList,
       operationType: "convert",
     });
-    expect(spyOnSettledPromisesEval).toHaveReturnedWith(
-      mockDistinctList.slice(1)
-    );
+    const expected: ReturnType<typeof settledPromisesEval> = {
+      successful: mockDistinctList.slice(1),
+      failed: [mockDistinctList[0]],
+    };
+    expect(spyOnSettledPromisesEval).toHaveReturnedWith(expected);
   });
   it("Should call console.log twice", async () => {
     await convertFiles(exampleArgs);

--- a/src/tests/mocks.ts
+++ b/src/tests/mocks.ts
@@ -1,8 +1,10 @@
 import { Dirent, Stats } from "fs";
+import { join } from "path";
 import type {
   BaseRenameItem,
   ExtractBaseAndExtReturn,
   ExtractBaseAndExtTemplate,
+  PromiseRejectedWriteResult,
   RenameItem,
   RenameItemsArray,
   RollbackFile
@@ -259,3 +261,16 @@ export const mockRenameListToolSet: RenameListToolSet = {
   renameLists,
   mockRollback: { sourcePath, transforms: [singleLevelTransform] },
 };
+
+
+export const generateRejected = ({
+  original,
+  rename,
+}: RenameItem | BaseRenameItem): PromiseRejectedWriteResult =>
+  ({
+    status: "rejected",
+    reason: {
+      path: join(sourcePath, rename),
+      dest: join(sourcePath, original),
+    },
+  } as PromiseRejectedWriteResult);

--- a/src/tests/mocks.ts
+++ b/src/tests/mocks.ts
@@ -265,12 +265,12 @@ export const mockRenameListToolSet: RenameListToolSet = {
 
 export const generateRejected = ({
   original,
-  rename,
-}: RenameItem | BaseRenameItem): PromiseRejectedWriteResult =>
+  rename,  
+}: RenameItem | BaseRenameItem, operationType: "convert"|"restore" = "restore"): PromiseRejectedWriteResult =>
   ({
     status: "rejected",
     reason: {
-      path: join(sourcePath, rename),
-      dest: join(sourcePath, original),
+      path: join(sourcePath, operationType === "restore" ? rename : original),
+      dest: join(sourcePath, operationType === "restore" ? original : rename),
     },
   } as PromiseRejectedWriteResult);

--- a/src/tests/restorePoint.spec.ts
+++ b/src/tests/restorePoint.spec.ts
@@ -9,6 +9,7 @@ import { restoreByLevels } from "../utils/restoreUtils.js";
 import * as utils from "../utils/utils.js";
 import {
   examplePath as transformPath,
+  generateRejected,
   mockDirentEntryAsFile,
   mockRenameListToolSet
 } from "./mocks.js";
@@ -198,15 +199,15 @@ describe("restoreOriginalFileNames", () => {
         .map((fileInfo) => fileInfo.name),
     });
     // Make second promise reject, to test for proper truncating of renamed list.
-    spyOnCreateBatchRenameList.mockReturnValueOnce([
+    const batchResults = [
       Promise.resolve(),
-      Promise.reject(),
-    ]);
-    // Create the appropriate allSettled data.
-    const promiseResults = [
-      { status: "fulfilled", value: undefined },
-      { status: "rejected", reason: undefined },
+      Promise.reject(
+        generateRejected(mockConversionList.restoreList.transforms[1]).reason
+      ),
     ];
+    spyOnCreateBatchRenameList.mockReturnValueOnce(batchResults);
+    // Create the appropriate allSettled data.
+    const promiseResults = await Promise.allSettled(batchResults);
     const expectedArgs = {
       promiseResults,
       operationType: "restore",

--- a/src/tests/utils.spec.ts
+++ b/src/tests/utils.spec.ts
@@ -17,8 +17,7 @@ import { ERRORS } from "../messages/errMessages.js";
 import { STATUS } from "../messages/statusMessages.js";
 import type {
   ComposeRenameStringArgs,
-  ExtractBaseAndExtTemplate,
-  RenameItemsArray,
+  ExtractBaseAndExtTemplate, RenameItemsArray,
   ValidTypes
 } from "../types.js";
 import * as utils from "../utils/utils.js";
@@ -27,6 +26,7 @@ import {
   examplePath,
   exampleStats,
   expectedSplit,
+  generateRejected,
   mockFileList,
   mockRenameListToolSet,
   mockRollbackToolSet,
@@ -46,6 +46,7 @@ const {
   parseBoolOption,
   parseRestoreArg,
   settledPromisesEval,
+  sortedJsonReplicate,
   truncateFile,
   trimRollbackFile,
 } = utils;
@@ -680,10 +681,6 @@ describe("settledPromisesEval", () => {
       operationType: "convert" as const,
     },
     settledLength = distinct.length,
-    rejected = {
-      status: "rejected",
-      reason: "someReason",
-    } as const,
     fulfilled = {
       status: "fulfilled",
       value: void 0,
@@ -692,13 +689,19 @@ describe("settledPromisesEval", () => {
     const promiseResults = new Array(settledLength).fill(
       fulfilled
     ) as PromiseSettledResult<void>[];
-    const result = settledPromisesEval({ ...args, promiseResults });
-    expect(result).toEqual(args.transformedNames);
+    const { failed, successful } = settledPromisesEval({
+      ...args,
+      promiseResults,
+    });
+    expect(successful).toEqual(args.transformedNames);
+    expect(failed.length).toBe(0);
   });
   it("Should throw error, if all promises are rejected", () => {
-    const promiseResults = new Array(settledLength).fill(
-      rejected
-    ) as PromiseSettledResult<void>[];
+    const promiseResults = new Array(settledLength)
+      .fill(0)
+      .map((entry, index) =>
+        generateRejected(distinct[index])
+      ) as PromiseSettledResult<void>[];
 
     expect(() => settledPromisesEval({ ...args, promiseResults })).toThrowError(
       ERRORS.utils.allRenameFailed
@@ -706,25 +709,25 @@ describe("settledPromisesEval", () => {
   });
   it("Should remove entries that resulted in rejected promises", () => {
     const promiseResults: PromiseSettledResult<void>[] = [
-      rejected,
+      generateRejected(distinct[0]),
       fulfilled,
-      rejected,
+      generateRejected(distinct[2]),
     ];
-    const result = settledPromisesEval({ ...args, promiseResults });
-    expect(result.length).toBe(distinct.length - 2);
-
-    const rejectedNames = [distinct[0].original, distinct[2].original];
-    const areRejectedPresent = result.some(({ original }) =>
-      rejectedNames.includes(original)
+    const { successful, failed } = settledPromisesEval({
+      ...args,
+      promiseResults,
+    });
+    expect(successful.length).toBe(distinct.length - 2);
+    expect(successful).toEqual([distinct[1]]);
+    expect(sortedJsonReplicate(failed)).toEqual(
+      sortedJsonReplicate([distinct[0], distinct[2]])
     );
-
-    expect(areRejectedPresent).toBe(false);
   });
   it("Should produce appropriate failReport and failItem messages", () => {
     const promiseResults: PromiseSettledResult<void>[] = [
       fulfilled,
       fulfilled,
-      rejected,
+      generateRejected(distinct[2]),
     ];
     for (const operationType of ["convert", "restore"] as const) {
       const { failReport, failItem } = STATUS.settledPromisesEval;

--- a/src/tests/utils.spec.ts
+++ b/src/tests/utils.spec.ts
@@ -701,7 +701,7 @@ describe("settledPromisesEval", () => {
     const promiseResults = new Array(settledLength)
       .fill(0)
       .map((entry, index) =>
-        generateRejected(distinct[index])
+        generateRejected(distinct[index], args.operationType)
       ) as PromiseSettledResult<void>[];
 
     expect(() => settledPromisesEval({ ...args, promiseResults })).toThrowError(
@@ -710,9 +710,9 @@ describe("settledPromisesEval", () => {
   });
   it("Should remove entries that resulted in rejected promises", () => {
     const promiseResults: PromiseSettledResult<void>[] = [
-      generateRejected(distinct[0]),
+      generateRejected(distinct[0], args.operationType),
       fulfilled,
-      generateRejected(distinct[2]),
+      generateRejected(distinct[2], args.operationType),
     ];
     const { successful, failed } = settledPromisesEval({
       ...args,
@@ -728,7 +728,7 @@ describe("settledPromisesEval", () => {
     const promiseResults: PromiseSettledResult<void>[] = [
       fulfilled,
       fulfilled,
-      generateRejected(distinct[2]),
+      generateRejected(distinct[2], args.operationType),
     ];
     for (const operationType of ["convert", "restore"] as const) {
       const { failReport, failItem } = STATUS.settledPromisesEval;

--- a/src/tests/utils.spec.ts
+++ b/src/tests/utils.spec.ts
@@ -165,6 +165,7 @@ describe("trimRollbackFile", () => {
   const trimArgs = {
     sourcePath: examplePath,
     targetLevel: 0,
+    failed: [],
   };
   afterAll(() => suppressStdOut.mockRestore());
   afterEach(() => jest.resetAllMocks());

--- a/src/types.ts
+++ b/src/types.ts
@@ -210,7 +210,7 @@ export type RestoreOriginalFileNames = (
 ) => Promise<void>;
 
 export type TrimRollbackFile = (
-  args: Omit<ConversionList, "transforms">
+  args: Omit<ConversionList, "transforms"> & {failed: RenameItemsArray}
 ) => Promise<void>;
 
 export type ListFiles = (

--- a/src/types.ts
+++ b/src/types.ts
@@ -301,7 +301,7 @@ export interface CheckExistingFiles {
   ({
     existingFiles,
     transforms,
-    rollbackLevel
+    rollbackLevel,
   }: {
     existingFiles: string[];
     transforms: RenameItemsArray[];
@@ -317,4 +317,14 @@ export interface CreateRollbackFile {
     transforms: BaseRenameList;
     sourcePath: string;
   }): Promise<RollbackFile>;
+}
+
+export interface PromiseRejectedWriteResult extends PromiseRejectedResult {
+  reason: {
+    errno: number;
+    code: string;
+    syscall: string;
+    path: string;
+    dest: string;
+  };
 }


### PR DESCRIPTION
* Fix reporting of failed files in settledPromisesEval (write operations do not enter in order they were started)
* Restore errors should be re-added to RollbackFile as most recent entry.