### PR TITLE
Feature/multilevel-rollback

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -6,5 +6,8 @@ module.exports = {
   extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
   rules: {
     "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-unused-vars":"off",
+    "@typescript-eslint/no-empty-function":"off",
+    "@typescript-eslint/no-non-null-assertion":"off",
   }
 };

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ workspace*
 .vscode
 coverage
 src/converters/helpers.ts
-.other

--- a/README.md
+++ b/README.md
@@ -3,8 +3,11 @@
 
 <br>
 
-## New feature
-Multi level rollback is now implemented. This means that you can perform multiple transformation on existing / newly added files, and then restore back to previous file names by levels. Just add the number of rollbacks you wish to perform next to the `restore` flag. Or omit the argument to roll back to the beginning!
+## New features
+- Multi level rollback is now implemented. This means that you can perform multiple transformation on existing / newly added files, and then restore back to previous file names by levels. Just add the number of rollbacks you wish to perform next to the `restore` flag. Or omit the argument to roll back to the beginning!
+  - Implementing the rollback feature meant a complete rewrite of the rollback logic. However, previous (legacy) rollback files are still supported and will be converted to the current format automatically.
+- All operations now run in dryRun by default so that changes can be previewed and executed via explicit confirmation.
+- Various bug fixes. Test improvements.
 
 ## How to run
 Clone the repo, then run `npm install`.
@@ -22,11 +25,11 @@ Rename files using a search and replace algorithm. Target folder set explicitly.
 
 Preview rename files by keeping only part of the name (the 'id-' tag with variable number of digits).
 
-`node batchRename.mjs -Dk "id-\d{1,}" --target [folder]`
+`node batchRename.mjs -k "id-\d{1,}" --target [folder]`
 
 Preview numeric transform with exclude option and a custom baseIndex. Folder path set implicitly.
 
-`node batchRename.mjs -Dn --exclude "excludedName" -b 100 "folder"`
+`node batchRename.mjs -n --exclude "excludedName" -b 100 "folder"`
 
 Append creation date to files AND folders in the current folder and specify a custom separator.
 
@@ -34,7 +37,7 @@ Append creation date to files AND folders in the current folder and specify a cu
 
 Preview the odd numbering transform with custom text append in a target folder.
 
-`node batchRename.mjs -n odd -f [targetFolder] -a CUSTOM_TEXT --textPosition append -D`
+`node batchRename.mjs -n odd -f [targetFolder] -a CUSTOM_TEXT --textPosition append`
 
 Rollback | restore to original file names in target folder.
 
@@ -54,7 +57,7 @@ To run the script successfully, you will have to provide one of the valid transf
 
 When performing the rename operation, the script will write a restore file (`.rollback.json`) to the target folder. Without this file, restore operations are not possible. 
 
-Before performing the rename, it is **strongly encouraged to perform a dry run first.** Dry run will present you with the rename preview information and warnings, as well as prompt you if the rename should be run or not.
+Dry run is enabled by default. This means that you will see planned changes and these will be executed only after explicitly confirming them. It is **strongly encouraged not to disable the dry run mode.** 
 
 The script will not perform a rename if it would lead to name collisions (i.e. several files sharing the same name).
 
@@ -71,7 +74,7 @@ The script will not perform a rename if it would lead to name collisions (i.e. s
 |`--target`|`<path>`|Folder in which the transformation should take place. *Can also be set implicitly* with an extra script argument (explicit setting takes precedence). If omitted, the script defaults to current working directory.|
 |`--targetType`|`['files'\|'dirs'\|'all']`|Determine which file types should be included in transform. Defaults to 'files' If omitted or supplied without option.|
 |`-r, --restore`|`[number]`|Restore transformed files to target rollback level. If no level is provided, maximum restore level will be used.|
-|`-D, --dryRun`||Run transform operation without writing to disk. Will log properties of expected output. Prompts user for transform execution, if no errors detected.|
+|`-D, --dryRun`|`<boolean>`|Log expected output and write only after confirmation. Defaults to true.|
 |`-b, --baseIndex`|`<number>`|For numeric transform, optional argument to specify the base index from which the sequencing will begin|
 |`--exclude`|`<string\|regex>`|Preemptively exclude files that match a given string or regular expression from being evaluated in the transform functions|
 |`-p, --preserveOriginal`|`[boolean]`| Preserve original file name. Not relevant for the `searchAndReplace` transform type. Defaults to `true`.|
@@ -92,6 +95,6 @@ The script will not perform a rename if it would lead to name collisions (i.e. s
 
 Performing renaming operations on files is not without risks. Things can go wrong, errors can happen, rollbacks might not succeed, data might be lost. So remember: 
 * Perform renaming operations only on files that you are prepared to lose or have backed up. 
-* Before performing the rename, always do a dry-run.
+* Default dry runs are enabled for a reason.
 * This script doesn't give you any guarantees or warranties about anything. 
 </div>

--- a/README.md
+++ b/README.md
@@ -4,10 +4,16 @@
 <br>
 
 ## New features
-- Multi level rollback is now implemented. This means that you can perform multiple transformation on existing / newly added files, and then restore back to previous file names by levels. Just add the number of rollbacks you wish to perform next to the `restore` flag. Or omit the argument to roll back to the beginning!
+- **Multi level rollback** is now implemented. Each rollback file now stores a history of all the transforms performed. This means you can perform multiple transformation on existing / newly added files, then restore back to previous file names by discrete levels. 
+  - Just add the number of rollbacks you wish to perform next to the `restore` flag. Or omit the argument to roll back to the beginning!
   - Implementing the rollback feature meant a complete rewrite of the rollback logic. However, previous (legacy) rollback files are still supported and will be converted to the current format automatically.
-- All operations now run in dryRun by default so that changes can be previewed and executed via explicit confirmation.
-- Various bug fixes. Test improvements.
+  - **Handling of failed restores**: If a restore operation fails on write (for example, because the file is locked by the OS), the failed restore files will be re-added to the rollback file as the most recent transformation so that the changes are not discarded. 
+- **Convert and restore operations run in dryRun by default** so that changes can be previewed and executed via explicit confirmation. 
+  - The `cleanRollbackFile` is an exception currently: it will run immediately, without confirm prompt.
+- Various bug fixes. Test improvements, mock files consolidation.
+
+- Despite best efforts and improved tests for the new features, some **buggy behavior can occur**.
+
 
 ## How to run
 Clone the repo, then run `npm install`.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,9 @@
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+
+const esModules = ["nanoid"].join("|");
+
 export default {
-  preset: "ts-jest/presets/js-with-ts-esm",
+  preset: "ts-jest/presets/default-esm",
   testEnvironment: "node",
   transform: {
     "\\.[jt]sx?$": "ts-jest",
@@ -8,8 +11,14 @@ export default {
   moduleNameMapper: {
     "(.+)\\.js": "$1",
   },
+  
   extensionsToTreatAsEsm: [".ts"],
   maxWorkers: 1,
   coveragePathIgnorePatterns: ["tests/", "programConfiguration"],
   collectCoverageFrom: ["**/*.ts"],
+  transformIgnorePatterns: [`/node_modules/(?!${esModules})`],
+  moduleNameMapper: {
+    "(.+)\\.js": "$1",
+    "^nanoid(/(.*)|$)": "nanoid$1",
+}
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,7 @@ export default {
   transform: {
     "\\.[jt]sx?$": "ts-jest",
   },
-  moduleNameMapper: {
+ moduleNameMapper: {
     "(.+)\\.js": "$1",
   },
   
@@ -17,8 +17,4 @@ export default {
   coveragePathIgnorePatterns: ["tests/", "programConfiguration"],
   collectCoverageFrom: ["**/*.ts"],
   transformIgnorePatterns: [`/node_modules/(?!${esModules})`],
-  moduleNameMapper: {
-    "(.+)\\.js": "$1",
-    "^nanoid(/(.*)|$)": "nanoid$1",
-}
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "@jericirenej/object-filter": "^1.3.1",
-        "commander": "^9.4.1"
+        "commander": "^9.4.1",
+        "nanoid": "^3.3.4"
       },
       "bin": {
         "batch-rename": "dist/index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4364,6 +4364,17 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -9019,6 +9030,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "type": "module",
   "dependencies": {
     "@jericirenej/object-filter": "^1.3.1",
-    "commander": "^9.4.1"
+    "commander": "^9.4.1",
+    "nanoid": "^3.3.4"
   },
   "devDependencies": {
     "@types/jest": "^29.2.1",

--- a/src/commands/parseCommands.ts
+++ b/src/commands/parseCommands.ts
@@ -5,7 +5,6 @@ import {
   VALID_TRANSFORM_TYPES
 } from "../constants.js";
 import { convertFiles } from "../converters/converter.js";
-import { checkPath } from "../converters/utils.js";
 import { ERRORS } from "../messages/errMessages.js";
 import type {
   OptionKeysWithValues,
@@ -16,6 +15,7 @@ import type {
   UtilityActions,
   UtilityActionsCheck
 } from "../types";
+import { checkPath } from "../utils/utils.js";
 import program from "./generateCommands.js";
 import { utilityActionsCorrespondenceTable } from "./programConfiguration.js";
 

--- a/src/commands/programConfiguration.ts
+++ b/src/commands/programConfiguration.ts
@@ -1,7 +1,7 @@
 import { PROGRAM_VERSION, VALID_DATE_TRANSFORM_TYPES } from "../constants.js";
 import { restoreOriginalFileNames } from "../converters/restorePoint.js";
-import { cleanUpRollbackFile } from "../converters/utils.js";
 import type { ProgramOptions } from "../types.js";
+import { cleanUpRollbackFile } from "../utils/utils.js";
 
 const programOptions: ProgramOptions[] = [
   {

--- a/src/commands/programConfiguration.ts
+++ b/src/commands/programConfiguration.ts
@@ -93,9 +93,9 @@ const programOptions: ProgramCLIOptions[] = [
   {
     short: "D",
     long: "dryRun",
-    type: "",
+    type: "<boolean>",
     description:
-      "Run transform operation without writing to disk. Run transform operation without writing to disk. Will log properties of expected output. Prompts user for transform execution, if no errors detected.",
+      "Log expected output and write only after confirmation. Defaults to true.",
     defaultValue: "",
   },
   {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,6 +19,7 @@ export const VALID_DATE_TRANSFORM_TYPES = [
 ] as const;
 
 export const EXT_REGEX =
+  // eslint-disable-next-line no-useless-escape
   /(?<=[\[\]\(\)\p{Alphabetic}\p{Decimal_Number}\p{Mark}-]+)(\.\w+)$/u;
 
 export const VALID_NUMERIC_TRANSFORM_TYPES = [

--- a/src/converters/addTextTransform.ts
+++ b/src/converters/addTextTransform.ts
@@ -1,5 +1,5 @@
 import type { AddTextTransform } from "../types.js";
-import { composeRenameString, truncateFile } from "./utils.js";
+import { composeRenameString, truncateFile } from "../utils/utils.js";
 
 export const addTextTransform: AddTextTransform = ({
   splitFileList,

--- a/src/converters/converter.ts
+++ b/src/converters/converter.ts
@@ -3,7 +3,7 @@ import { resolve } from "path";
 import {
   ROLLBACK_FILE_NAME,
   VALID_DRY_RUN_ANSWERS,
-  VALID_TRANSFORM_TYPES,
+  VALID_TRANSFORM_TYPES
 } from "../constants.js";
 import { ERRORS } from "../messages/errMessages.js";
 import { STATUS } from "../messages/statusMessages.js";
@@ -11,18 +11,12 @@ import type {
   DryRunTransform,
   ExtractBaseAndExtReturn,
   FileListWithStatsArray,
+  GeneralTransformReturn,
   GenerateRenameList,
   GenerateRenameListArgs,
-  RenameListArgs,
+  LegacyRenameList,
+  RenameListArgs
 } from "../types";
-import { addTextTransform } from "./addTextTransform.js";
-import { dateTransform, provideFileStats } from "./dateTransform.js";
-import { extensionModifyTransform } from "./extensionModify.js";
-import { formatTextTransform } from "./formatTextTransform.js";
-import { keepTransform } from "./keepTransform.js";
-import { numericTransform } from "./numericTransform.js";
-import { searchAndReplace } from "./searchAndReplace.js";
-import { truncateTransform } from "./truncateTransform.js";
 import {
   areNewNamesDistinct,
   askQuestion,
@@ -31,8 +25,16 @@ import {
   extractBaseAndExt,
   listFiles,
   numberOfDuplicatedNames,
-  settledPromisesEval,
-} from "./utils.js";
+  settledPromisesEval
+} from "../utils/utils.js";
+import { addTextTransform } from "./addTextTransform.js";
+import { dateTransform, provideFileStats } from "./dateTransform.js";
+import { extensionModifyTransform } from "./extensionModify.js";
+import { formatTextTransform } from "./formatTextTransform.js";
+import { keepTransform } from "./keepTransform.js";
+import { numericTransform } from "./numericTransform.js";
+import { searchAndReplace } from "./searchAndReplace.js";
+import { truncateTransform } from "./truncateTransform.js";
 const { duplicateRenames, noTransformFunctionAvailable } = ERRORS.transforms;
 const {
   exitWithoutTransform,
@@ -45,7 +47,7 @@ const {
 
 export const TRANSFORM_CORRESPONDENCE_TABLE: Record<
   typeof VALID_TRANSFORM_TYPES[number],
-  Function
+  (args: GenerateRenameListArgs)=> LegacyRenameList|GeneralTransformReturn
 > = {
   addText: (args: GenerateRenameListArgs) => addTextTransform(args),
   dateRename: (args: GenerateRenameListArgs) => dateTransform(args),

--- a/src/converters/converter.ts
+++ b/src/converters/converter.ts
@@ -112,14 +112,14 @@ export const convertFiles = async (args: RenameListArgs): Promise<void> => {
   const batchRename = createBatchRenameList(transforms);
   console.log(`Renaming ${batchRename.length} files...`);
   const promiseResults = await Promise.allSettled(batchRename);
-  const updatedRenameList = settledPromisesEval({
+  const updatedBaseRenameList = settledPromisesEval({
     promiseResults,
     transformedNames: transforms.transforms,
     operationType: "convert",
-  });
+  }).successful;
 
   const createdRollback = await createRollback({
-    transforms: updatedRenameList,
+    transforms: updatedBaseRenameList,
     sourcePath: targetDir,
   });
   console.log("Rename completed!");

--- a/src/converters/dateTransform.ts
+++ b/src/converters/dateTransform.ts
@@ -10,7 +10,7 @@ import type {
   FormattedDate,
   ProvideFileStats
 } from "../types";
-import { composeRenameString } from "./utils.js";
+import { composeRenameString } from "../utils/utils.js";
 
 export const provideFileStats: ProvideFileStats = async (splitFileList) => {
   const splitFileListWithStats: FileListWithStatsArray = await Promise.all(
@@ -62,8 +62,8 @@ export const dateTransform: DateTransform = ({
   noExtensionPreserve
 }) => {
   const statProp = dateTransformCorrespondenceTable[dateRename!];
-  let originalFileList = splitFileList as FileListWithStatsArray;
-  let fileListWithDates: FileListWithDates[] = originalFileList.map(
+  const originalFileList = splitFileList as FileListWithStatsArray;
+  const fileListWithDates: FileListWithDates[] = originalFileList.map(
     (fileInfo) => {
       const { baseName, stats, ext, sourcePath, type } = fileInfo;
       const formattedDate = extractDate(stats[statProp] as number);

--- a/src/converters/formatTextTransform.ts
+++ b/src/converters/formatTextTransform.ts
@@ -1,5 +1,5 @@
 import { FormatTextTransform, ValidTextFormats } from "../types.js";
-import { composeRenameString } from "./utils.js";
+import { composeRenameString } from "../utils/utils.js";
 
 export const formatTextTransform: FormatTextTransform = ({
   splitFileList,

--- a/src/converters/keepTransform.ts
+++ b/src/converters/keepTransform.ts
@@ -1,5 +1,5 @@
 import type { KeepTransform } from "../types";
-import { composeRenameString } from "./utils.js";
+import { composeRenameString } from "../utils/utils.js";
 
 export const keepTransform: KeepTransform = ({
   keep,

--- a/src/converters/keepTransform.ts
+++ b/src/converters/keepTransform.ts
@@ -1,4 +1,4 @@
-import type { BaseRenameItem, KeepTransform } from "../types";
+import type { BaseRenameItem, BaseRenameList, KeepTransform } from "../types";
 import { composeRenameString } from "../utils/utils.js";
 
 export const keepTransform: KeepTransform = ({
@@ -15,7 +15,8 @@ export const keepTransform: KeepTransform = ({
 }) => {
   const regexBase = `^.*(?=${keep})|(?<=${keep}).*$`;
   const matcher = new RegExp(regexBase, "gu");
-  return splitFileList.map((fileInfo) => {
+  const renameList:BaseRenameList = [];
+  splitFileList.forEach((fileInfo) => {
     const { baseName: _baseName, ext } = fileInfo;
     const baseName = noExtensionPreserve ? `${_baseName}${ext}` : _baseName;
     const original = `${_baseName}${ext}`;
@@ -28,7 +29,11 @@ export const keepTransform: KeepTransform = ({
       addText,
       format,
     });
-    const renameItem: BaseRenameItem = { rename: `${newName}`, original };
-    return renameItem;
+    const rename = `${newName}`;
+    if(rename !== original) {
+      const renameItem: BaseRenameItem = { rename: `${newName}`, original };
+      renameList.push(renameItem);
+    }
   });
+  return renameList;
 };

--- a/src/converters/numericTransform.ts
+++ b/src/converters/numericTransform.ts
@@ -1,6 +1,6 @@
 import { VALID_NUMERIC_TRANSFORM_TYPES as numericTransformFunctions } from "../constants.js";
 import type { NumericTransform } from "../types";
-import { composeRenameString } from "./utils.js";
+import { composeRenameString } from "../utils/utils.js";
 
 /**Return a list of odd|even names, along with original file names */
 export const numericTransform: NumericTransform = ({
@@ -22,7 +22,7 @@ export const numericTransform: NumericTransform = ({
   return splitFileList.map((splitFile, index) => {
     const indexWithBase = baseIndex ? baseIndex + index : index;
     const { ext, baseName, sourcePath } = splitFile;
-    let sequenceNumber = generateSequenceNumber(
+    const sequenceNumber = generateSequenceNumber(
       numericTransform!,
       indexWithBase,
       baseIndex

--- a/src/converters/restorePoint.ts
+++ b/src/converters/restorePoint.ts
@@ -12,7 +12,7 @@ import type {
 } from "../types";
 import {
   checkExistingFiles,
-  checkRestoreFile, restoreByLevels
+  checkRestoreFile, determineRollbackLevel, restoreByLevels
 } from "../utils/restoreUtils.js";
 import {
   askQuestion, createBatchRenameList,
@@ -50,10 +50,12 @@ export const restoreBaseFunction: RestoreBaseFunction = async (
   const originalRollbackData = JSON.parse(readRollback);
   
   const rollbackData = checkRestoreFile(originalRollbackData);
+  const targetRollback = determineRollbackLevel({transformList: rollbackData.transforms, rollbackLevel})
 
   const { filesToRestore, missingFiles } = checkExistingFiles({
     existingFiles,
     transforms: rollbackData.transforms,
+    rollbackLevel: targetRollback
   });
   const restoreList = restoreByLevels({ rollbackFile: rollbackData, rollbackLevel });
 

--- a/src/converters/restorePoint.ts
+++ b/src/converters/restorePoint.ts
@@ -12,13 +12,17 @@ import type {
 } from "../types";
 import {
   checkExistingFiles,
-  checkRestoreFile, determineRollbackLevel, restoreByLevels
+  checkRestoreFile,
+  determineRollbackLevel,
+  restoreByLevels
 } from "../utils/restoreUtils.js";
 import {
-  askQuestion, createBatchRenameList,
+  askQuestion,
+  createBatchRenameList,
   determineDir,
   listFiles,
-  settledPromisesEval, trimRollbackFile
+  settledPromisesEval,
+  trimRollbackFile
 } from "../utils/utils.js";
 
 const { couldNotBeParsed, noFilesToConvert, noRollbackFile, noValidData } =
@@ -32,7 +36,7 @@ const {
 
 export const restoreBaseFunction: RestoreBaseFunction = async (
   transformPath,
-  rollbackLevel,
+  rollbackLevel
 ) => {
   const targetDir = determineDir(transformPath);
   const targetPath = join(targetDir, ROLLBACK_FILE_NAME);
@@ -48,16 +52,22 @@ export const restoreBaseFunction: RestoreBaseFunction = async (
   }
   const readRollback = await readFile(targetPath, "utf8");
   const originalRollbackData = JSON.parse(readRollback);
-  
+
   const rollbackData = checkRestoreFile(originalRollbackData);
-  const targetRollback = determineRollbackLevel({transformList: rollbackData.transforms, rollbackLevel})
+  const targetRollback = determineRollbackLevel({
+    transformList: rollbackData.transforms,
+    rollbackLevel,
+  });
 
   const { filesToRestore, missingFiles } = checkExistingFiles({
     existingFiles,
     transforms: rollbackData.transforms,
-    rollbackLevel: targetRollback
+    rollbackLevel: targetRollback,
   });
-  const restoreList = restoreByLevels({ rollbackFile: rollbackData, rollbackLevel });
+  const restoreList = restoreByLevels({
+    rollbackFile: rollbackData,
+    rollbackLevel,
+  });
 
   return {
     rollbackData,
@@ -72,7 +82,7 @@ export const restoreBaseFunction: RestoreBaseFunction = async (
 export const restoreOriginalFileNames: RestoreOriginalFileNames = async ({
   dryRun,
   transformPath,
-  rollbackLevel
+  rollbackLevel,
 }) => {
   const targetDir = determineDir(transformPath);
   const restoreBaseData = await restoreBaseFunction(targetDir, rollbackLevel);
@@ -85,12 +95,16 @@ export const restoreOriginalFileNames: RestoreOriginalFileNames = async ({
     if (!dryRun) return;
   }
   const { filesToRestore, restoreList } = restoreBaseData;
-  const {targetLevel, transforms} = restoreList;
+  const { targetLevel, transforms } = restoreList;
 
   let batchRename: Promise<void>[] = [],
     updatedRenameList: RenameItemsArray = [];
   if (filesToRestore.length) {
-    batchRename = createBatchRenameList({transforms, sourcePath: targetDir, filesToRestore});
+    batchRename = createBatchRenameList({
+      transforms,
+      sourcePath: targetDir,
+      filesToRestore,
+    });
   }
   if (!batchRename.length) {
     throw new Error(couldNotBeParsed);
@@ -103,13 +117,13 @@ export const restoreOriginalFileNames: RestoreOriginalFileNames = async ({
     console.log(`Will revert ${batchRename.length} files...`);
     const promiseResults = await Promise.allSettled(batchRename);
 
-    settledPromisesEval({
+    const { failed } = settledPromisesEval({
       promiseResults,
       transformedNames: updatedRenameList,
       operationType: "restore",
     });
 
-    await trimRollbackFile({ sourcePath:targetDir, targetLevel });
+    await trimRollbackFile({ sourcePath: targetDir, targetLevel, failed });
   }
 };
 

--- a/src/converters/restorePoint.ts
+++ b/src/converters/restorePoint.ts
@@ -6,9 +6,9 @@ import { ERRORS } from "../messages/errMessages.js";
 import { STATUS } from "../messages/statusMessages.js";
 import type {
   DryRunRestore,
-  RenameList,
+  LegacyRenameList,
   RestoreBaseFunction,
-  RestoreOriginalFileNames,
+  RestoreOriginalFileNames
 } from "../types";
 import {
   askQuestion,
@@ -16,8 +16,8 @@ import {
   createBatchRenameList,
   determineDir,
   listFiles,
-  settledPromisesEval,
-} from "./utils.js";
+  settledPromisesEval
+} from "../utils/utils.js";
 
 const { couldNotBeParsed, noFilesToConvert, noRollbackFile, noValidData } =
   ERRORS.restore;
@@ -44,7 +44,7 @@ export const restoreBaseFunction: RestoreBaseFunction = async (
     throw new Error(noRollbackFile);
   }
   const readRollback = await readFile(targetPath, "utf8");
-  const rollbackData = JSON.parse(readRollback) as RenameList;
+  const rollbackData = JSON.parse(readRollback) as LegacyRenameList;
 
   const missingFiles: string[] = [];
   rollbackData.forEach((info) => {
@@ -76,7 +76,7 @@ export const restoreOriginalFileNames: RestoreOriginalFileNames = async ({
   const { rollbackData, filesToRestore } = restoreBaseData;
 
   let batchRename: Promise<void>[] = [],
-    updatedRenameList: RenameList = [];
+    updatedRenameList: LegacyRenameList = [];
   if (filesToRestore.length) {
     batchRename = createBatchRenameList(rollbackData, filesToRestore);
   }

--- a/src/converters/searchAndReplace.ts
+++ b/src/converters/searchAndReplace.ts
@@ -1,10 +1,10 @@
 import { Dirent } from "fs";
 import type {
   GenerateSearchAndReplaceArgs,
-  SearchAndReplace,
+  SearchAndReplace
 } from "../types.js";
+import { extractBaseAndExt, truncateFile } from "../utils/utils.js";
 import { formatFile } from "./formatTextTransform.js";
-import { extractBaseAndExt, truncateFile } from "./utils.js";
 
 export const searchAndReplace: SearchAndReplace = ({
   searchAndReplace,
@@ -16,7 +16,7 @@ export const searchAndReplace: SearchAndReplace = ({
   const generatedArgs = generateSearchAndReplaceArgs(searchAndReplace!);
   const targetList = splitFileList.map((fileInfo) => {
     const { filter, replace } = generatedArgs;
-    let { baseName, sourcePath, ext, type } = fileInfo;
+    const { baseName, sourcePath, ext, type } = fileInfo;
     const original = `${baseName}${ext}`;
     let rename = noExtensionPreserve ? original : baseName;
     if (filter && filter.test(original)) {

--- a/src/converters/truncateTransform.ts
+++ b/src/converters/truncateTransform.ts
@@ -1,6 +1,6 @@
 import { ERRORS } from "../messages/errMessages.js";
 import type { TruncateTransform } from "../types.js";
-import { composeRenameString } from "./utils.js";
+import { composeRenameString } from "../utils/utils.js";
 const {truncateNoPreserveOriginal, truncateInvalidArgument } = ERRORS.transforms;
 
 export const truncateTransform: TruncateTransform = ({

--- a/src/legacyTypes.ts
+++ b/src/legacyTypes.ts
@@ -1,6 +1,0 @@
-import type { BaseRenameItem } from "./types.js";
-
-export interface LegacyRenameItem extends BaseRenameItem {
-  sourcePath: string;
-}
-export type LegacyRenameList = LegacyRenameItem[];

--- a/src/messages/errMessages.ts
+++ b/src/messages/errMessages.ts
@@ -8,6 +8,10 @@ export const ERRORS = {
     couldNotBeParsed: "Restore data could not be parsed for any of the files!",
     noValidData: "No valid data was returned from the restoreBaseFunction!",
   },
+  restoreFileMapper: {
+    zeroLevelRollback: "Restore level 0 provided. No restore performed.",
+    incorrectRollbackFormat: "The rollback file does not conform to the required format!",
+  },
   cleanRollback: {
     noRollbackFile: "No rollback file exists. Exiting.",
     rollbackOperationFail: "Cleaning up rollback file failed!",

--- a/src/messages/index.ts
+++ b/src/messages/index.ts
@@ -1,0 +1,2 @@
+export * from "./errMessages";
+export * from "./statusMessages";

--- a/src/messages/statusMessages.ts
+++ b/src/messages/statusMessages.ts
@@ -28,6 +28,21 @@ export const STATUS = {
       "Would you like to execute the restore of original entry names (N/Y)?",
     exitWithoutRestore: "Exited application without performing restore.",
   },
+  restoreFileMapper: {
+    rollbackLevelOverMax:
+      "Specified rollback level is higher than the combined number of stored batch operations. Will map to initial entry.",
+    rollbackLevelsLessThanTarget: (
+      filesWithLessLevels: number,
+      allFiles: number
+    ) => {
+      const endMessage = "Will rollback to the earliest possible version."
+      if (filesWithLessLevels === allFiles) {
+        return `All files have less rollback levels than requested. ${endMessage}`;
+      }
+      return `${filesWithLessLevels} number of files have less rollback levels than requested. ${endMessage}`;
+    },
+    legacyConversion: "Legacy rollback file format found. Will be converted to current format."
+  },
   settledPromisesEval: {
     failReport: (
       promisesRejected: number,

--- a/src/tests/addTextTransform.spec.ts
+++ b/src/tests/addTextTransform.spec.ts
@@ -1,9 +1,9 @@
 import { addTextTransform } from "../converters/addTextTransform.js";
 import * as formatText from "../converters/formatTextTransform.js";
-import * as utils from "../converters/utils.js";
 import type { GenerateRenameListArgs } from "../types.js";
+import * as utils from "../utils/utils.js";
 import { generateMockSplitFileList } from "./mocks.js";
-let splitFileList = generateMockSplitFileList(2);
+const splitFileList = generateMockSplitFileList(2);
 const exampleArgs: GenerateRenameListArgs = {
   addText: "addText",
   textPosition: undefined,

--- a/src/tests/converter.spec.ts
+++ b/src/tests/converter.spec.ts
@@ -5,20 +5,20 @@ import * as dateTransformFunctions from "../converters/dateTransform.js";
 import * as numericTransformFunctions from "../converters/numericTransform.js";
 import * as searchAndReplaceTransformFunctions from "../converters/searchAndReplace.js";
 import * as truncateTransformFunctions from "../converters/truncateTransform.js";
-import * as utils from "../converters/utils.js";
 import { ERRORS } from "../messages/errMessages.js";
 import type {
   DryRunTransformArgs,
-  RenameList,
+  LegacyRenameList,
   RenameListArgs,
-  TransformTypes,
+  TransformTypes
 } from "../types.js";
+import * as utils from "../utils/utils.js";
 import {
   examplePath,
   exampleStats,
   generateMockSplitFileList,
   mockFileList,
-  renameListDistinct,
+  renameListDistinct
 } from "./mocks.js";
 
 jest.mock("fs/promises", () => {
@@ -303,7 +303,7 @@ describe("dryRunTransform", () => {
     expect(checkTypeArgs).toEqual(expectedArgs);
   });
   it("Should return false, if no names would be changed by transform", async () => {
-    const identicalTransform: RenameList = [renameListDistinct[0]];
+    const identicalTransform: LegacyRenameList = [renameListDistinct[0]];
     identicalTransform[0].rename = identicalTransform[0].original;
     expect(
       await dryRunTransform({

--- a/src/tests/dateTransform.spec.ts
+++ b/src/tests/dateTransform.spec.ts
@@ -3,7 +3,6 @@ import { stat } from "fs/promises";
 import { DEFAULT_SEPARATOR } from "../constants.js";
 import * as dateTransforms from "../converters/dateTransform.js";
 import * as formatText from "../converters/formatTextTransform.js";
-import * as utils from "../converters/utils.js";
 import type {
   ComposeRenameStringArgs,
   DateTransformCorrespondenceTable,
@@ -11,6 +10,7 @@ import type {
   FormattedDate,
   GenerateRenameListArgs
 } from "../types.js";
+import * as utils from "../utils/utils.js";
 import { exampleStats as stats, generateMockSplitFileList } from "./mocks.js";
 
 jest.mock("fs/promises", () => {

--- a/src/tests/extensionModify.spec.ts
+++ b/src/tests/extensionModify.spec.ts
@@ -2,11 +2,11 @@ import { EXT_REGEX } from "../constants.js";
 import { extensionModifyTransform } from "../converters/extensionModify.js";
 import type {
   GenerateRenameListArgs,
-  RenameList
+  LegacyRenameList
 } from "../types.js";
 import { generateMockSplitFileList } from "./mocks.js";
 
-const returnExtension = (renameList: RenameList): string[] => {
+const returnExtension = (renameList: LegacyRenameList): string[] => {
   return renameList.map((fileTransform) => {
     const { rename } = fileTransform;
     const extPosition = rename.search(EXT_REGEX);

--- a/src/tests/keepTransform.spec.ts
+++ b/src/tests/keepTransform.spec.ts
@@ -1,5 +1,5 @@
 import { keepTransform } from "../converters/keepTransform.js";
-import type { KeepTransformArgs, RenameList } from "../types.js";
+import type { KeepTransformArgs, LegacyRenameList } from "../types.js";
 import { mockKeepList as splitFileList } from "./mocks.js";
 
 describe("keepTransform", () => {
@@ -12,14 +12,14 @@ describe("keepTransform", () => {
   }));
   afterEach(() => jest.clearAllMocks());
   it("With only 'keep' arg, return should contain only matched string with extension", () => {
-    const expected: RenameList = splitFileList.map(({ ext }, index) => ({
+    const expected: LegacyRenameList = splitFileList.map(({ ext }, index) => ({
       rename: `Part00${index + 1}${ext}`,
       ...baseExpect[index],
     }));
     expect(keepTransform(baseArgs)).toEqual(expected);
   });
   it("Will perform specified transforms on target files", () => {
-    const testCases: { args: KeepTransformArgs; expected: RenameList }[] = [
+    const testCases: { args: KeepTransformArgs; expected: LegacyRenameList }[] = [
       {
         args: { ...baseArgs, format: "uppercase" },
         expected: splitFileList.map(({ ext }, index) => ({

--- a/src/tests/keepTransform.spec.ts
+++ b/src/tests/keepTransform.spec.ts
@@ -1,6 +1,11 @@
 import { keepTransform } from "../converters/keepTransform.js";
-import type { BaseRenameList, KeepTransformArgs } from "../types.js";
-import { mockKeepList as splitFileList } from "./mocks.js";
+import type {
+  BaseRenameList,
+  ExtractBaseAndExtReturn,
+  KeepTransformArgs
+} from "../types.js";
+import { jsonReplicate } from "../utils/utils.js";
+import { examplePath, mockKeepList as splitFileList } from "./mocks.js";
 
 describe("keepTransform", () => {
   const keep = `Part(\\d{3})`;
@@ -49,5 +54,22 @@ describe("keepTransform", () => {
     for (const { args, expected } of testCases) {
       expect(keepTransform(args)).toEqual(expected);
     }
+  });
+  it("Will only return non-identical transforms", () => {
+    const splitListWithIdenticalTransform: ExtractBaseAndExtReturn = [
+      ...jsonReplicate(splitFileList),
+      {
+        baseName: "Part005",
+        ext: "ext",
+        sourcePath: examplePath,
+        type: "file",
+      },
+    ];
+    const args: KeepTransformArgs = {
+      splitFileList: splitListWithIdenticalTransform,
+      keep,
+    };
+    const result = keepTransform(args);
+    expect(result.length).toBe(splitFileList.length);
   });
 });

--- a/src/tests/mocks.ts
+++ b/src/tests/mocks.ts
@@ -1,5 +1,4 @@
 import { Dirent, Stats } from "fs";
-import type { LegacyRenameList } from "../legacyTypes.js";
 import type {
   BaseRenameItem,
   ExtractBaseAndExtReturn,
@@ -8,6 +7,7 @@ import type {
   RenameItemsArray,
   RollbackFile
 } from "../types.js";
+import type { LegacyRenameList } from "../utils/restoreUtils.js";
 import { extractBaseAndExt } from "../utils/utils.js";
 
 export const mockDirentEntryAsFile: Omit<Dirent, "name"> = {

--- a/src/tests/mocks.ts
+++ b/src/tests/mocks.ts
@@ -1,8 +1,10 @@
 import { Dirent, Stats } from "fs";
+import { join } from "path";
 import type {
   BaseRenameItem,
   ExtractBaseAndExtReturn,
   ExtractBaseAndExtTemplate,
+  PromiseRejectedWriteResult,
   RenameItem,
   RenameItemsArray,
   RollbackFile
@@ -259,3 +261,16 @@ export const mockRenameListToolSet: RenameListToolSet = {
   renameLists,
   mockRollback: { sourcePath, transforms: [singleLevelTransform] },
 };
+
+
+export const generateRejected = ({
+  original,
+  rename,  
+}: RenameItem | BaseRenameItem, operationType: "convert"|"restore" = "restore"): PromiseRejectedWriteResult =>
+  ({
+    status: "rejected",
+    reason: {
+      path: join(sourcePath, operationType === "restore" ? rename : original),
+      dest: join(sourcePath, operationType === "restore" ? original : rename),
+    },
+  } as PromiseRejectedWriteResult);

--- a/src/tests/numericTransform.spec.ts
+++ b/src/tests/numericTransform.spec.ts
@@ -1,8 +1,8 @@
 import { DEFAULT_SEPARATOR } from "../constants.js";
 import * as formatText from "../converters/formatTextTransform.js";
 import * as numericConverter from "../converters/numericTransform.js";
-import * as utils from "../converters/utils.js";
 import type { GenerateRenameListArgs } from "../types.js";
+import * as utils from "../utils/utils.js";
 import { generateMockSplitFileList } from "./mocks.js";
 
 const { numericTransform, checkBaseIndex } = numericConverter;

--- a/src/tests/parseCommands.spec.ts
+++ b/src/tests/parseCommands.spec.ts
@@ -6,12 +6,12 @@ import {
   VALID_TRANSFORM_TYPES
 } from "../constants.js";
 import * as converters from "../converters/converter.js";
-import * as utils from "../converters/utils.js";
 import { ERRORS } from "../messages/errMessages.js";
 import type {
   OptionKeysWithValues,
   OptionKeysWithValuesAndRestArgs
 } from "../types.js";
+import * as utils from "../utils/utils.js";
 import { examplePath } from "./mocks.js";
 
 const {

--- a/src/tests/parseCommands.spec.ts
+++ b/src/tests/parseCommands.spec.ts
@@ -92,6 +92,22 @@ describe("parseOptions", () => {
     expect(preserveOriginal).toBe(true);
     spyOnToLowerCase.mockRestore();
   });
+  it("Should set dryRun to false only if explicitly stated", async () => {
+    const testCases = [
+      { val: undefined, expected: true },
+      { val: "true", expected: true },
+      { val: "false", expected: false },
+    ];
+    for (const { val, expected } of testCases) {
+      if (val === undefined) {
+        await parseOptions({ ...exampleArgs });
+      } else {
+        await parseOptions({ ...exampleArgs, dryRun: val });
+      }
+      const dryRunArg = spyOnConvertFiles.mock.calls.flat().at(-1)?.dryRun;
+      expect(dryRunArg).toBe(expected);
+    }
+  });
   it("Should properly evaluate a stringified preserveOriginal argument", async () => {
     spyOnConvertFiles.mockClear();
     [
@@ -113,9 +129,8 @@ describe("parseOptions", () => {
       { ...exampleArgs, noExtensionPreserve: true, detailedDate: true },
       { ...exampleArgs, format: "uppercase" },
     ];
-    const extraKeys = ["transformPattern", "transformPath"];
+    const extraKeys = ["transformPattern", "transformPath", "dryRun"];
     argList.forEach(async (args) => {
-      await parseOptions(exampleArgs);
       spyOnConvertFiles.mockClear();
       await parseOptions(args);
       const expectedKeys = extraKeys.concat(
@@ -124,7 +139,9 @@ describe("parseOptions", () => {
         )
       );
       const receivedKeys = Object.keys(spyOnConvertFiles.mock.calls.flat()[0]);
-      expect(receivedKeys.every(key => expectedKeys.includes(key))).toBe(true);
+      expect(receivedKeys.every((key) => expectedKeys.includes(key))).toBe(
+        true
+      );
     });
   });
 });

--- a/src/tests/restorePoint.spec.ts
+++ b/src/tests/restorePoint.spec.ts
@@ -9,6 +9,7 @@ import { restoreByLevels } from "../utils/restoreUtils.js";
 import * as utils from "../utils/utils.js";
 import {
   examplePath as transformPath,
+  generateRejected,
   mockDirentEntryAsFile,
   mockRenameListToolSet
 } from "./mocks.js";
@@ -198,15 +199,15 @@ describe("restoreOriginalFileNames", () => {
         .map((fileInfo) => fileInfo.name),
     });
     // Make second promise reject, to test for proper truncating of renamed list.
-    spyOnCreateBatchRenameList.mockReturnValueOnce([
+    const batchResults = [
       Promise.resolve(),
-      Promise.reject(),
-    ]);
-    // Create the appropriate allSettled data.
-    const promiseResults = [
-      { status: "fulfilled", value: undefined },
-      { status: "rejected", reason: undefined },
+      Promise.reject(
+        generateRejected(mockConversionList.restoreList.transforms[1]).reason
+      ),
     ];
+    spyOnCreateBatchRenameList.mockReturnValueOnce(batchResults);
+    // Create the appropriate allSettled data.
+    const promiseResults = await Promise.allSettled(batchResults);
     const expectedArgs = {
       promiseResults,
       operationType: "restore",

--- a/src/tests/restorePoint.spec.ts
+++ b/src/tests/restorePoint.spec.ts
@@ -24,7 +24,7 @@ const { couldNotBeParsed, noFilesToConvert, noRollbackFile, noValidData } =
 const { restoreBaseFunction, restoreOriginalFileNames, dryRunRestore } =
   restorePoint;
 
-const { jsonReplicate } = utils;
+const { sortedJsonReplicate } = utils;
 const {
   renameLists: { distinct },
   mockRollback,
@@ -90,20 +90,27 @@ describe("restoreBaseFunction", () => {
     mockedFs.existsSync.mockReturnValueOnce(true);
     mockedReadFile.mockResolvedValueOnce(JSON.stringify(mockRollback));
     mockedNanoId.mockReturnValue(mockReference);
-    const rollbackList = await restoreBaseFunction(transformPath);
-    expect(rollbackList.rollbackData).toEqual(mockRollback);
-    expect(jsonReplicate(rollbackList.existingFiles).sort()).toEqual(jsonReplicate(mockRenamedList).sort());
-    expect(rollbackList.missingFiles.length).toBe(0);
-    expect(jsonReplicate(rollbackList.filesToRestore).sort()).toEqual(jsonReplicate(mockRenamedList).sort());
+    const { filesToRestore, rollbackData, existingFiles, missingFiles } =
+      await restoreBaseFunction(transformPath);
+    expect(rollbackData).toEqual(mockRollback);
+    expect(sortedJsonReplicate(existingFiles)).toEqual(
+      sortedJsonReplicate(mockRenamedList)
+    );
+    expect(missingFiles.length).toBe(0);
+    expect(sortedJsonReplicate(filesToRestore)).toEqual(
+      sortedJsonReplicate(mockRenamedList)
+    );
   });
   it("Should log missing fileNames in restoreFile", async () => {
     spyOnListFiles.mockResolvedValueOnce(mockFileList.slice(0, -1));
     mockedFs.existsSync.mockReturnValueOnce(true);
     mockedReadFile.mockResolvedValueOnce(JSON.stringify(mockRollback));
-    const rollbackList = await restoreBaseFunction(transformPath);
-    expect(rollbackList.missingFiles).toEqual(mockRenamedList.slice(-1));
-    expect(jsonReplicate(rollbackList.filesToRestore).sort()).toEqual(
-      jsonReplicate(mockRenamedList.slice(0, -1)).sort()
+    const { filesToRestore, missingFiles } = await restoreBaseFunction(
+      transformPath
+    );
+    expect(missingFiles).toEqual(mockRenamedList.slice(-1));
+    expect(sortedJsonReplicate(filesToRestore)).toEqual(
+      sortedJsonReplicate(mockRenamedList.slice(0, -1))
     );
   });
 });

--- a/src/tests/restorePoint.spec.ts
+++ b/src/tests/restorePoint.spec.ts
@@ -1,16 +1,16 @@
 import fs, { PathLike } from "fs";
 import { readFile, rename } from "fs/promises";
 import * as restorePoint from "../converters/restorePoint.js";
-import * as utils from "../converters/utils.js";
 import { ERRORS } from "../messages/errMessages.js";
 import { STATUS } from "../messages/statusMessages.js";
 import type { RestoreBaseReturn } from "../types.js";
+import * as utils from "../utils/utils.js";
 import {
   examplePath as transformPath,
   mockDirentEntryAsFile,
   renameListDistinct as renameList
 } from "./mocks.js";
-jest.mock("fs");
+jest.mock("fs",);
 jest.mock("fs/promises", () => {
   return {
     readFile: jest.fn(),

--- a/src/tests/restorePoint.spec.ts
+++ b/src/tests/restorePoint.spec.ts
@@ -9,7 +9,8 @@ import { restoreByLevels } from "../utils/restoreUtils.js";
 import * as utils from "../utils/utils.js";
 import {
   examplePath as transformPath,
-  mockDirentEntryAsFile, mockRenameListToolSet
+  mockDirentEntryAsFile,
+  mockRenameListToolSet
 } from "./mocks.js";
 jest.mock("fs");
 jest.mock("fs/promises", () => {
@@ -23,10 +24,15 @@ const { couldNotBeParsed, noFilesToConvert, noRollbackFile, noValidData } =
 const { restoreBaseFunction, restoreOriginalFileNames, dryRunRestore } =
   restorePoint;
 
-const {renameLists:{distinct}, mockRollback, originalNames} = mockRenameListToolSet
+const { jsonReplicate } = utils;
+const {
+  renameLists: { distinct },
+  mockRollback,
+  originalNames,
+} = mockRenameListToolSet;
 
 jest.mock("../messages/statusMessages.js");
-jest.mock("nanoid")
+jest.mock("nanoid");
 const mockedNanoId = jest.mocked(nanoid);
 const statusMocked = jest.mocked(STATUS);
 
@@ -52,7 +58,6 @@ const mockedReadFile = jest.mocked(readFile);
 const mockedRename = jest.mocked(rename);
 
 const baseArg = { transformPath };
-
 
 const mockConversionList: RestoreBaseReturn = {
   existingFiles: mockFileList.map((file) => file.name),
@@ -87,9 +92,9 @@ describe("restoreBaseFunction", () => {
     mockedNanoId.mockReturnValue(mockReference);
     const rollbackList = await restoreBaseFunction(transformPath);
     expect(rollbackList.rollbackData).toEqual(mockRollback);
-    expect(rollbackList.existingFiles).toEqual(mockRenamedList);
+    expect(jsonReplicate(rollbackList.existingFiles).sort()).toEqual(jsonReplicate(mockRenamedList).sort());
     expect(rollbackList.missingFiles.length).toBe(0);
-    expect(rollbackList.filesToRestore).toEqual(mockRenamedList);
+    expect(jsonReplicate(rollbackList.filesToRestore).sort()).toEqual(jsonReplicate(mockRenamedList).sort());
   });
   it("Should log missing fileNames in restoreFile", async () => {
     spyOnListFiles.mockResolvedValueOnce(mockFileList.slice(0, -1));
@@ -97,7 +102,9 @@ describe("restoreBaseFunction", () => {
     mockedReadFile.mockResolvedValueOnce(JSON.stringify(mockRollback));
     const rollbackList = await restoreBaseFunction(transformPath);
     expect(rollbackList.missingFiles).toEqual(mockRenamedList.slice(-1));
-    expect(rollbackList.filesToRestore).toEqual(mockRenamedList.slice(0, -1));
+    expect(jsonReplicate(rollbackList.filesToRestore).sort()).toEqual(
+      jsonReplicate(mockRenamedList.slice(0, -1)).sort()
+    );
   });
 });
 

--- a/src/tests/restoreUtils.spec.ts
+++ b/src/tests/restoreUtils.spec.ts
@@ -1,0 +1,333 @@
+import { jest } from "@jest/globals";
+import type { SpyInstance } from "jest-mock";
+import { nanoid } from "nanoid";
+import { ERRORS, STATUS } from "../messages/index.js";
+import { RenameItemsArray, RestoreList, RollbackFile } from "../types.js";
+import * as restoreUtils from "../utils/restoreUtils.js";
+import {
+  examplePath as sourcePath,
+  newRenameList,
+  newRollbackFile,
+  renameListDistinct
+} from "./mocks.js";
+
+const {
+  buildRestoreFile,
+  checkRestoreFile,
+  determineRollbackLevel,
+  isCurrentRestore,
+  isLegacyRestore,
+  legacyRestoreMapper,
+  restoreFileMapper,
+} = restoreUtils;
+
+const { incorrectRollbackFormat, zeroLevelRollback } = ERRORS.restoreFileMapper;
+const { legacyConversion, rollbackLevelOverMax } = STATUS.restoreFileMapper;
+
+jest.mock("nanoid");
+const mockedNanoId = jest.mocked(nanoid);
+
+const renameSequence = (baseName: string, length: number) =>
+  new Array(length)
+    .fill(0)
+    .map((entry, index) => `${length - index}-${baseName}`);
+
+describe("determineRollbackLevel", () => {
+  const rollbackLength = 10,
+    transformList = new Array(rollbackLength).fill(
+      newRenameList
+    ) as RenameItemsArray[];
+  let spyOnConsole: SpyInstance;
+  beforeEach(
+    () =>
+      (spyOnConsole = jest
+        .spyOn(console, "log")
+        .mockImplementation((message?: any) => {}))
+  );
+  afterEach(() => jest.clearAllMocks());
+  afterAll(() => spyOnConsole.mockRestore());
+  it("Should throw error, if rollback level is 0", () => {
+    expect(() =>
+      determineRollbackLevel({ transformList, rollbackLevel: 0 })
+    ).toThrowError(zeroLevelRollback);
+  });
+  it("Should set restore index to the last array entry (length-1) if rollbackLevel is over maximum", () => {
+    expect(
+      determineRollbackLevel({
+        transformList,
+        rollbackLevel: rollbackLength + 1,
+      })
+    ).toBe(rollbackLength);
+  });
+  it("Should notify the user, if rollbackLevel is over maximum", () => {
+    expect(spyOnConsole).not.toHaveBeenCalled();
+    determineRollbackLevel({
+      transformList,
+      rollbackLevel: rollbackLength + 1,
+    });
+    expect(spyOnConsole).toHaveBeenCalledWith(rollbackLevelOverMax);
+  });
+  it("Should return the target index", () => {
+    [1, 2, 3, 5].forEach((rollbackLevel) =>
+      expect(
+        determineRollbackLevel({
+          transformList,
+          rollbackLevel,
+        })
+      ).toBe(rollbackLevel)
+    );
+  });
+});
+
+describe("isLegacyRestore", () => {
+  it("Should return false for falsy values and non-arrays", () => {
+    for (const testCase of [
+      undefined,
+      null,
+      "something",
+      "",
+      35,
+      {},
+      { property: "property" },
+    ]) {
+      expect(isLegacyRestore(testCase)).toBe(false);
+    }
+  });
+  it("Should return false for new rename list types", () => {
+    expect(isLegacyRestore(newRollbackFile)).toBe(false);
+  });
+  it("Should return true for a legacy restore list", () => {
+    expect(isLegacyRestore(renameListDistinct)).toBe(true);
+  });
+});
+
+describe("legacyRestoreMapper", () => {
+  it("Should transform legacy rollback files", () => {
+    renameListDistinct.forEach((entry, index) =>
+      mockedNanoId.mockReturnValueOnce(`nanoCode-${index}`)
+    );
+    const mappedResult = legacyRestoreMapper(renameListDistinct);
+    const mappedItems: RenameItemsArray[] = [
+      renameListDistinct.map(({ original, rename }, index) => ({
+        original,
+        rename,
+        referenceId: `nanoCode-${index}`,
+      })),
+    ];
+    const expected: RollbackFile = {
+      sourcePath: renameListDistinct[0].sourcePath,
+      transforms: mappedItems,
+    };
+    expect(mappedResult).toEqual(expected);
+  });
+});
+
+describe("isCurrentRestore", () => {
+  it("Should return false for falsy values, arrays and primitives", () => {
+    for (const testCase of [
+      undefined,
+      null,
+      "something",
+      "",
+      35,
+      [],
+      [1, 2, 3],
+    ]) {
+      expect(isCurrentRestore(testCase)).toBe(false);
+    }
+  });
+  it("Should return false for legacy rollback file", () =>
+    expect(isCurrentRestore(renameListDistinct)).toBe(false));
+  it("Should return true for new rename list type", () =>
+    expect(isCurrentRestore(newRollbackFile)).toBe(true));
+  it("Should return false for improper top level keys", () => {
+    const improperKeys = {
+      firstProp: newRollbackFile.sourcePath,
+      someTransformProp: [...newRollbackFile.transforms],
+    };
+    expect(isCurrentRestore(improperKeys)).toBe(false);
+  });
+  it("Should return false if one of the transforms has improper key or non-string value", () => {
+    const renameCopy = JSON.parse(
+      JSON.stringify(newRollbackFile)
+    ) as RollbackFile;
+    const improperKey = renameCopy.transforms[0].map(
+      ({ original, referenceId, rename }) => ({
+        original,
+        rename,
+        someReference: referenceId,
+      })
+    );
+    const improperValue = renameCopy.transforms[0].map(
+      ({ original, referenceId, rename }) => ({
+        original,
+        rename,
+        referenceId: 55,
+      })
+    );
+    for (const testCase of [improperKey, improperValue])
+      expect(isCurrentRestore(testCase)).toBe(false);
+  });
+});
+
+describe("checkRestoreFile", () => {
+  const arg = "someArg";
+  const spyOnCurrentRestore = jest.spyOn(restoreUtils, "isCurrentRestore"),
+    spyOnLegacyRestore = jest.spyOn(restoreUtils, "isLegacyRestore"),
+    spyOnLegacyRestoreMapper = jest.spyOn(restoreUtils, "legacyRestoreMapper");
+  let spyOnConsole: SpyInstance<typeof console.log>;
+  beforeEach(() => {
+    spyOnConsole = jest
+      .spyOn(console, "log")
+      .mockImplementation((message?: any) => {});
+    jest.clearAllMocks();
+  });
+  afterAll(() => spyOnConsole.mockRestore());
+  it("Should throw an error, if supplied param is not legacy or current restore file", () => {
+    [spyOnCurrentRestore, spyOnLegacyRestore].forEach((spy) =>
+      spy.mockReturnValueOnce(false)
+    );
+    expect(() => checkRestoreFile(arg)).toThrowError(incorrectRollbackFormat);
+  });
+  it("Should return current rollback param directly", () => {
+    spyOnCurrentRestore.mockReturnValueOnce(true);
+    expect(checkRestoreFile(arg)).toEqual(arg);
+    [spyOnLegacyRestore, spyOnConsole, spyOnLegacyRestoreMapper].forEach(
+      (spy) => expect(spy).not.toHaveBeenCalled()
+    );
+  });
+  it("Should emit message, and return result for legacy restore arg", () => {
+    const mappedResult = "mappedResult";
+    spyOnCurrentRestore.mockReturnValueOnce(false);
+    spyOnLegacyRestore.mockReturnValueOnce(true);
+    spyOnLegacyRestoreMapper.mockReturnValueOnce(mappedResult as any);
+    expect(checkRestoreFile(arg)).toEqual(mappedResult);
+    expect(spyOnConsole).toHaveBeenCalledWith(legacyConversion);
+  });
+});
+
+describe("buildRestoreFile", () => {
+  let spyOnConsole: SpyInstance<typeof console.log>,
+    spyOnTable: SpyInstance<typeof console.table>;
+  const restoreChain = 5,
+    targetLevel = restoreChain - 1,
+    refId1 = "refId1",
+    refId2 = "refId2";
+  const restoreList: Record<string, string[]> = {
+    [refId1]: renameSequence(refId1, restoreChain),
+    [refId2]: renameSequence(refId2, restoreChain),
+  };
+  beforeEach(() => {
+    spyOnConsole = jest
+      .spyOn(console, "log")
+      .mockImplementation((message?: any) => {});
+    spyOnTable = jest
+      .spyOn(console, "table")
+      .mockImplementation(
+        (tabularData: any, properties?: readonly string[]) => {}
+      );
+    jest.clearAllMocks();
+  });
+  afterAll(() => {
+    spyOnConsole.mockRestore();
+    spyOnTable.mockRestore();
+  });
+
+  it("Should produce a restore list", () => {
+    const expected: RestoreList = {
+      sourcePath,
+      transforms: [refId1, refId2].map((entry) => ({
+        rename: `5-${entry}`,
+        original: `1-${entry}`,
+        referenceId: entry,
+      })),
+    };
+
+    const result = buildRestoreFile({
+      restoreList,
+      sourcePath,
+      targetLevel,
+    });
+    expect(result).toEqual(expected);
+  });
+  describe("Handling of restore chains with elements that have fewer levels than requested", () => {
+    const newRestoreList = JSON.parse(JSON.stringify(restoreList)) as Record<
+      string,
+      string[]
+    >;
+
+    newRestoreList[refId2] = newRestoreList[refId2].slice(0, -2);
+    it("Should produce a restore list with latest available rollbacks", () => {
+      const expected: RestoreList = {
+        sourcePath,
+        transforms: [refId1, refId2].map((entry) => ({
+          rename: `5-${entry}`,
+          original: `${entry === refId1 ? 1 : 3}-${entry}`,
+          referenceId: entry,
+        })),
+      };
+      const result = buildRestoreFile({
+        restoreList: newRestoreList,
+        sourcePath,
+        targetLevel,
+      });
+      expect(result).toEqual(expected);
+    });
+    it("Should inform the user that some files have less rollback levels", () => {
+      buildRestoreFile({ restoreList, sourcePath, targetLevel });
+      [spyOnConsole, spyOnTable].forEach((spy) =>
+        expect(spy).not.toHaveBeenCalled()
+      );
+      buildRestoreFile({
+        restoreList: newRestoreList,
+        sourcePath,
+        targetLevel,
+      });
+      [spyOnConsole, spyOnTable].forEach((spy) =>
+        expect(spy).toHaveBeenCalled()
+      );
+    });
+  });
+});
+
+describe("restoreFileMapper", () => {
+  const args = { rollbackFile: newRollbackFile };
+  it("Should call determineRollbackLevel", () => {
+    const spyOnDetermineRollback = jest.spyOn(
+      restoreUtils,
+      "determineRollbackLevel"
+    );
+    restoreFileMapper(args);
+    expect(spyOnDetermineRollback).toHaveBeenCalledTimes(1);
+  });
+  it("Should call buildRestoreFile", () => {
+    const spyOnBuildRestoreFile = jest.spyOn(restoreUtils, "buildRestoreFile");
+    restoreFileMapper(args);
+    expect(spyOnBuildRestoreFile).toHaveBeenCalledTimes(1);
+  });
+  it("Should call buildRestoreFile with appropriate args", () => {
+    const spyOnConsole = jest
+      .spyOn(console, "log")
+      .mockImplementationOnce((message?: any) => {});
+    const spyOnBuildRestoreFile = jest.spyOn(restoreUtils, "buildRestoreFile");
+    const { transforms } = newRollbackFile;
+    const targetLevel = transforms.length,
+      sourcePath = newRollbackFile.sourcePath;
+    const restoreList = {} as Record<string, string[]>;
+    [3, 2, 1].forEach((entry) => {
+      const propName = `000${entry}`;
+      restoreList[propName] = [
+        `thirdRename${entry}`,
+        `secondRename${entry}`,
+        `rename${entry}`,
+        `original${entry}`,
+      ];
+    });
+    restoreFileMapper({ ...args, rollbackLevel: Infinity });
+    expect(spyOnBuildRestoreFile).toHaveBeenCalledWith({
+      restoreList,
+      targetLevel,
+      sourcePath,
+    });
+  });
+});

--- a/src/tests/searchAndReplace.spec.ts
+++ b/src/tests/searchAndReplace.spec.ts
@@ -1,11 +1,11 @@
 import * as formatText from "../converters/formatTextTransform.js";
 import * as regexTransform from "../converters/searchAndReplace.js";
-import * as utils from "../converters/utils.js";
 import { GenerateRenameListArgs } from "../types.js";
+import * as utils from "../utils/utils.js";
 import {
   generateMockSplitFileList,
   mockDirentEntryAsFile,
-  mockSplitFile,
+  mockSplitFile
 } from "./mocks.js";
 
 const { extractBaseAndExt } = utils;
@@ -114,7 +114,7 @@ describe("searchAndReplace", () => {
     const customMocksList = generateMockSplitFileList(2);
     customMocksList[0].baseName = "extra-extra";
     // Remove all 'ext' characters, except if preceded by string.
-    let filter = "(?<!\\.)ext";
+    const filter = "(?<!\\.)ext";
     const newArgs: GenerateRenameListArgs = {
       ...exampleArgs,
       searchAndReplace: [filter, "ult"],

--- a/src/tests/truncateTransform.spec.ts
+++ b/src/tests/truncateTransform.spec.ts
@@ -1,9 +1,9 @@
 import { DEFAULT_SEPARATOR } from "../constants.js";
 import * as formatText from "../converters/formatTextTransform.js";
 import { truncateTransform } from "../converters/truncateTransform.js";
-import * as utils from "../converters/utils.js";
 import { ERRORS } from "../messages/errMessages.js";
-import type { GenerateRenameListArgs, RenameList } from "../types.js";
+import type { GenerateRenameListArgs, LegacyRenameList } from "../types.js";
+import * as utils from "../utils/utils.js";
 import { generateMockSplitFileList } from "./mocks.js";
 
 const spyOnCompose = jest.spyOn(utils, "composeRenameString");
@@ -71,7 +71,7 @@ describe("truncateTransform", () => {
     });
   });
   it("Should return proper response", () => {
-    const expected: RenameList = splitFileList.map((fileInfo) => {
+    const expected: LegacyRenameList = splitFileList.map((fileInfo) => {
       const { baseName, ext, sourcePath } = fileInfo;
       return {
         rename: mockComposeResponse,
@@ -81,11 +81,16 @@ describe("truncateTransform", () => {
     });
     expect(truncateTransform(defaultArgs)).toEqual(expected);
   });
-  it("Should call formatFile (via composeRenameString), if format argument passed", ()=> {
+  it("Should call formatFile (via composeRenameString), if format argument passed", () => {
     spyOnCompose.mockRestore();
     const spyOnFormatFile = jest.spyOn(formatText, "formatFile");
-    const argsWithFormat:GenerateRenameListArgs = {...defaultArgs, format: "uppercase"};
-    [defaultArgs, argsWithFormat].forEach(args => truncateTransform(args));
-    expect(spyOnFormatFile).toHaveBeenCalledTimes(defaultArgs.splitFileList.length);
-  })
+    const argsWithFormat: GenerateRenameListArgs = {
+      ...defaultArgs,
+      format: "uppercase",
+    };
+    [defaultArgs, argsWithFormat].forEach((args) => truncateTransform(args));
+    expect(spyOnFormatFile).toHaveBeenCalledTimes(
+      defaultArgs.splitFileList.length
+    );
+  });
 });

--- a/src/tests/utils.spec.ts
+++ b/src/tests/utils.spec.ts
@@ -66,7 +66,7 @@ const mockedReadDir = jest.mocked(readdir);
 const mockedUnlink = jest.mocked(unlink);
 
 describe("cleanUpRollbackFile", () => {
-  let suppressStdOut: SpyInstance<(message:string) => boolean>;
+  let suppressStdOut: SpyInstance<(message:string|Uint8Array) => boolean>;
   beforeEach(
     () =>
       (suppressStdOut = jest

--- a/src/tests/utils.spec.ts
+++ b/src/tests/utils.spec.ts
@@ -43,6 +43,7 @@ const {
   extractCurrentReferences,
   listFiles,
   numberOfDuplicatedNames,
+  parseBoolOption,
   parseRestoreArg,
   settledPromisesEval,
   truncateFile,
@@ -80,6 +81,23 @@ const mockedFs = jest.mocked(fs),
   mockedUnlink = jest.mocked(unlink),
   mockedReadFile = jest.mocked(readFile),
   mockedWriteFile = jest.mocked(writeFile);
+
+describe("parseBoolOption", () => {
+  it("Should return default value, if arg is falsy or would throw error", () => {
+    [undefined, null, 12345, "truthy", "falsy"].forEach((option) => {
+      [false, true].forEach((defaultArg) => {
+        expect(parseBoolOption(option, defaultArg)).toBe(defaultArg);
+      });
+    });
+  });
+  it("Should pass the parsed string boolean", () => {
+    ["true", "false"].forEach((option) => {
+      [false, true].forEach((defaultArg) => {
+        expect(parseBoolOption(option, defaultArg)).toBe(JSON.parse(option));
+      });
+    });
+  });
+});
 
 describe("parseRestoreArg", () => {
   it("Should return an integer for stringified number values", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -210,7 +210,7 @@ export type RestoreOriginalFileNames = (
 ) => Promise<void>;
 
 export type TrimRollbackFile = (
-  args: Omit<ConversionList, "transforms">
+  args: Omit<ConversionList, "transforms"> & {failed: RenameItemsArray}
 ) => Promise<void>;
 
 export type ListFiles = (
@@ -301,7 +301,7 @@ export interface CheckExistingFiles {
   ({
     existingFiles,
     transforms,
-    rollbackLevel
+    rollbackLevel,
   }: {
     existingFiles: string[];
     transforms: RenameItemsArray[];
@@ -317,4 +317,14 @@ export interface CreateRollbackFile {
     transforms: BaseRenameList;
     sourcePath: string;
   }): Promise<RollbackFile>;
+}
+
+export interface PromiseRejectedWriteResult extends PromiseRejectedResult {
+  reason: {
+    errno: number;
+    code: string;
+    syscall: string;
+    path: string;
+    dest: string;
+  };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -301,9 +301,11 @@ export interface CheckExistingFiles {
   ({
     existingFiles,
     transforms,
+    rollbackLevel
   }: {
     existingFiles: string[];
     transforms: RenameItemsArray[];
+    rollbackLevel: number;
   }): { filesToRestore: string[]; missingFiles: string[] };
 }
 

--- a/src/utils/restoreUtils.ts
+++ b/src/utils/restoreUtils.ts
@@ -1,5 +1,4 @@
 import { nanoid } from "nanoid";
-import type { LegacyRenameList } from "../legacyTypes.js";
 import { ERRORS, STATUS } from "../messages/index.js";
 import type {
   CheckExistingFiles,
@@ -10,6 +9,13 @@ import type {
   RollbackFile
 } from "../types";
 import { jsonReplicate } from "./utils.js";
+
+import type { BaseRenameItem } from "../types.js";
+
+export interface LegacyRenameItem extends BaseRenameItem {
+  sourcePath: string;
+}
+export type LegacyRenameList = LegacyRenameItem[];
 
 const { incorrectRollbackFormat } = ERRORS.restoreFileMapper;
 const { legacyConversion, rollbackLevelOverMax, rollbackLevelsLessThanTarget } =
@@ -26,7 +32,7 @@ export const checkExistingFiles: CheckExistingFiles = ({
     fileNames = new Set(existingFiles);
 
   const flattenedTransforms = transforms.slice(0,rollbackLevel).flat();
-  const hashMap: Map<string, string[]> = flattenedTransforms.reduce(
+  const hashMap = flattenedTransforms.reduce(
     (map, { referenceId, rename }) => {
       const target = map.get(referenceId);
       target ? map.set(referenceId, [...target, rename]) : map.set(referenceId, [rename]);

--- a/src/utils/restoreUtils.ts
+++ b/src/utils/restoreUtils.ts
@@ -1,0 +1,197 @@
+import { nanoid } from "nanoid";
+import { join } from "path";
+import { ERRORS, STATUS } from "../messages/index.js";
+import type {
+  BuildRestoreFile,
+  DetermineRollbackLevel,
+  FilesWithMissingRestores,
+  LegacyRenameList,
+  RenameItem,
+  RenameItemsArray,
+  RestoreFileMapper,
+  RestoreList,
+  RollbackFile
+} from "../types";
+
+const { incorrectRollbackFormat, zeroLevelRollback } = ERRORS.restoreFileMapper;
+const { legacyConversion, rollbackLevelOverMax, rollbackLevelsLessThanTarget } =
+  STATUS.restoreFileMapper;
+
+export const determineRollbackLevel: DetermineRollbackLevel = ({
+  transformList,
+  rollbackLevel = 1,
+}) => {
+  if (rollbackLevel === 0) throw new Error(zeroLevelRollback);
+  let targetRestoreLevel = rollbackLevel;
+  const maximumRestoreLevel = transformList.length;
+  if (rollbackLevel > maximumRestoreLevel) {
+    console.log(rollbackLevelOverMax);
+    targetRestoreLevel = maximumRestoreLevel;
+  }
+  return targetRestoreLevel;
+};
+
+/**Convert legacy rollback file which supported only single rollbacks to the new
+ * rollback format. */
+export const legacyRestoreMapper = (
+  legacyRollbackFile: LegacyRenameList
+): RollbackFile => {
+  const sourcePath = legacyRollbackFile[0].sourcePath;
+  const restoreList: RestoreList = { sourcePath, transforms: [] };
+  const legacyRollbackWithReferenceId: RenameItemsArray =
+    legacyRollbackFile.map(({ rename, original }) => ({
+      original,
+      rename,
+      referenceId: nanoid(),
+    }));
+  return { ...restoreList, transforms: [[...legacyRollbackWithReferenceId]] };
+};
+
+/**Type guard for legacy restore files */
+export const isLegacyRestore = (
+  rollbackFile: unknown
+): rollbackFile is LegacyRenameList => {
+  if (!(rollbackFile && Array.isArray(rollbackFile))) return false;
+  const legacyProps = ["rename", "original", "sourcePath"];
+  const isLegacy = rollbackFile.every((entry) => {
+    const objEntries = Object.entries(entry);
+    if (objEntries.length !== legacyProps.length) return false;
+    for (const [key, value] of objEntries) {
+      const isValueString = typeof value === "string";
+      const isKeyIncluded = legacyProps.includes(key);
+      const conditions = [isValueString, isKeyIncluded].every(
+        (evaluation) => evaluation
+      );
+      if (!conditions) return false;
+    }
+    return true;
+  });
+  return isLegacy;
+};
+
+/**Type guard for current restore files */
+export const isCurrentRestore = (
+  rollbackFile: unknown
+): rollbackFile is RollbackFile => {
+  if (!rollbackFile) return false;
+  if (Array.isArray(rollbackFile)) return false;
+  if (typeof rollbackFile !== "object") return false;
+  const keys = Object.keys(rollbackFile);
+  const topLevelKeys: (keyof RollbackFile)[] = ["sourcePath", "transforms"];
+  const areKeysPresent =
+    keys.length === topLevelKeys.length &&
+    topLevelKeys.every((key) => key in rollbackFile);
+  if (!areKeysPresent) return false;
+
+  const topLevelObject = rollbackFile as Record<keyof RollbackFile, any>;
+  const areTopLevelProperTypes =
+    typeof topLevelObject.sourcePath === "string" &&
+    Array.isArray(topLevelObject.transforms);
+  if (!areTopLevelProperTypes) return false;
+
+  const renameItemKeys: (keyof RenameItem)[] = [
+    "original",
+    "referenceId",
+    "rename",
+  ];
+  const isEachTransformProper = (topLevelObject.transforms as any[]).every(
+    (transform) => {
+      if (!Array.isArray(transform)) return false;
+      for (const fileTransform of transform) {
+        if (Array.isArray(fileTransform) || typeof fileTransform !== "object")
+          return false;
+
+        const areKeysProper = renameItemKeys.every(
+          (key) => fileTransform[key] && typeof fileTransform[key] === "string"
+        );
+        if (!areKeysProper) return false;
+      }
+      return true;
+    }
+  );
+
+  return isEachTransformProper;
+};
+
+/**Check that the rollbackFile conforms to either the current or legacy
+ * rollback file type. Converts legacy rollbacks to current type.
+ * Throws error, if file does not conform.*/
+export const checkRestoreFile = (rollbackFile: unknown): RollbackFile => {
+  if (isCurrentRestore(rollbackFile)) return rollbackFile;
+  if (isLegacyRestore(rollbackFile)) {
+    console.log(legacyConversion);
+    return legacyRestoreMapper(rollbackFile);
+  }
+  throw new Error(incorrectRollbackFormat);
+};
+
+/**Evaluate the restore list. For elements that have fewer restores than
+ * the target level, log this to the console. Return a single transform from
+ * the latest file to the target (or earliest available) original name */
+export const buildRestoreFile: BuildRestoreFile = ({
+  restoreList,
+  targetLevel,
+  sourcePath,
+}) => {
+  const filesWithMissingRestores = [] as FilesWithMissingRestores[];
+  const entries = Object.entries(restoreList);
+  const transformRestore: RestoreList = { sourcePath, transforms: [] };
+  entries.forEach(([referenceId, transformList]) => {
+    const [rename, original] = [
+      transformList[0],
+      transformList[transformList.length - 1],
+    ];
+    // Transform list should be equal to number of rollbacks + current name
+    if (transformList.length < targetLevel + 1) {
+      filesWithMissingRestores.push({
+        file: join(sourcePath, rename).replaceAll("\\", "/"),
+        found: transformList.length - 1,
+        requested: targetLevel,
+      });
+    }
+    return transformRestore.transforms.push({ rename, original, referenceId });
+  });
+  // Notify if some transforms restore levels are less than requested
+  if (filesWithMissingRestores.length) {
+    console.log(
+      rollbackLevelsLessThanTarget(
+        filesWithMissingRestores.length,
+        entries.length
+      )
+    );
+    console.table(filesWithMissingRestores);
+  }
+  return transformRestore;
+};
+
+export const restoreFileMapper: RestoreFileMapper = ({
+  rollbackFile,
+  rollbackLevel = 1,
+}): any => {
+  const { transforms, sourcePath } = rollbackFile;
+  const targetLevel = determineRollbackLevel({
+    transformList: transforms,
+    rollbackLevel,
+  });
+  const restoreList = {} as Record<string, string[]>;
+  const flatTransform = transforms.slice(0, targetLevel).flat(2);
+  const uniqueReferences = [
+    ...new Set(flatTransform.map(({ referenceId }) => referenceId)),
+  ];
+  uniqueReferences.forEach((reference) => {
+    const referenceTransformSequence = flatTransform.reduce(
+      (acc, { original, rename, referenceId }) => {
+        if (!(referenceId === reference)) return acc;
+        if (!acc.length) {
+          return acc = [rename, original];
+        }
+        // Remove the last element, so we don't get duplication
+        // between the original and previous rename.
+        return acc = [...acc.slice(0, -1), rename, original];
+      },
+      [] as string[]
+    );
+    restoreList[reference] = [...referenceTransformSequence];
+  });
+  return buildRestoreFile({ restoreList, targetLevel, sourcePath });
+};

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -190,8 +190,9 @@ export const listFiles: ListFiles = async (
       return dirEntry.isDirectory();
     });
   if (excludeFilter) {
-    const regex = new RegExp(excludeFilter);
-    files = files.filter((fileName) => !regex.test(fileName.name));
+    // Global flag should not be used, as inconsistent results will occur
+    const regex = new RegExp(excludeFilter, "u");
+    files = files.filter(({ name }) => !regex.test(name));
   }
   return files;
 };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -52,6 +52,7 @@ const { failReport, failItem } = STATUS.settledPromisesEval;
 export const jsonParseReplicate = <T>(arg: string): T => JSON.parse(arg) as T;
 export const jsonReplicate = <T>(arg: T): T =>
   jsonParseReplicate(JSON.stringify(arg)) as T;
+export const sortedJsonReplicate = <T extends unknown[]>(arg:T):T => jsonReplicate(arg).sort();
 
 export const parseRestoreArg = (arg: unknown): number => {
   try {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -6,8 +6,9 @@ import {
   DEFAULT_SEPARATOR,
   DEFAULT_TARGET_TYPE,
   EXT_REGEX,
-  ROLLBACK_FILE_NAME,
+  ROLLBACK_FILE_NAME
 } from "../constants.js";
+import { formatFile } from "../converters/formatTextTransform.js";
 import { ERRORS } from "../messages/errMessages.js";
 import { STATUS } from "../messages/statusMessages.js";
 import type {
@@ -18,12 +19,11 @@ import type {
   CreateBatchRenameList,
   DetermineDir,
   ExtractBaseAndExt,
+  LegacyRenameList,
   ListFiles,
   NumberOfDuplicatedNames,
-  RenameList,
-  TruncateFileName,
+  TruncateFileName
 } from "../types.js";
-import { formatFile } from "./formatTextTransform.js";
 
 const {
   allRenameFailed,
@@ -121,7 +121,7 @@ export const numberOfDuplicatedNames: NumberOfDuplicatedNames = ({
 }) => {
   if (checkType === "results") {
     const renames = renameList.map((renameInfo) => renameInfo.rename);
-    let newNamesUniqueLength = new Set(renames).size;
+    const newNamesUniqueLength = new Set(renames).size;
     return renames.length - newNamesUniqueLength;
   }
   if (checkType === "transforms") {
@@ -272,10 +272,10 @@ export const settledPromisesEval = ({
   promiseResults,
   operationType,
 }: {
-  transformedNames: RenameList;
+  transformedNames: LegacyRenameList;
   promiseResults: PromiseSettledResult<void>[];
   operationType: "convert" | "restore";
-}): RenameList => {
+}): LegacyRenameList => {
   const promisesRejected = promiseResults.filter(
     (settledResult) => settledResult.status === "rejected"
   ).length;
@@ -285,7 +285,7 @@ export const settledPromisesEval = ({
     throw new Error(allRenameFailed);
 
   console.log(failReport(promisesRejected, operationType));
-  const truncatedList: RenameList = [];
+  const truncatedList: LegacyRenameList = [];
   promiseResults.forEach((settledResult, index) => {
     if (settledResult.status === "rejected") {
       const { original, rename } = transformedNames[index];

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -52,7 +52,18 @@ const { failReport, failItem } = STATUS.settledPromisesEval;
 export const jsonParseReplicate = <T>(arg: string): T => JSON.parse(arg) as T;
 export const jsonReplicate = <T>(arg: T): T =>
   jsonParseReplicate(JSON.stringify(arg)) as T;
-export const sortedJsonReplicate = <T extends unknown[]>(arg:T):T => jsonReplicate(arg).sort();
+export const sortedJsonReplicate = <T extends unknown[]>(arg: T): T =>
+  jsonReplicate(arg).sort();
+
+export const parseBoolOption = (arg?: unknown, defaultVal = false): boolean => {
+  try {
+    if (!arg) return defaultVal;
+    const parsed = JSON.parse(String(arg).toLowerCase());
+    return typeof parsed === "boolean" ? parsed : defaultVal;
+  } catch {
+    return defaultVal;
+  }
+};
 
 export const parseRestoreArg = (arg: unknown): number => {
   try {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -7,7 +7,7 @@ import {
   unlink,
   writeFile
 } from "fs/promises";
-import { join, resolve } from "path";
+import { join, parse, resolve } from "path";
 import readline from "readline";
 import {
   DEFAULT_SEPARATOR,
@@ -30,6 +30,8 @@ import type {
   ExtractBaseAndExt,
   ListFiles,
   NumberOfDuplicatedNames,
+  PromiseRejectedWriteResult,
+  RenameItem,
   RenameItemsArray,
   RollbackFile,
   TrimRollbackFile,
@@ -116,6 +118,7 @@ export const extractCurrentReferences = (
 export const trimRollbackFile: TrimRollbackFile = async ({
   sourcePath,
   targetLevel,
+  failed,
 }) => {
   const targetDir = determineDir(sourcePath);
   const targetPath = resolve(targetDir, ROLLBACK_FILE_NAME);
@@ -126,23 +129,59 @@ export const trimRollbackFile: TrimRollbackFile = async ({
   const rollbackFile = JSON.parse(await readFile(targetPath, "utf-8"));
 
   const verifiedRollback = checkRestoreFile(rollbackFile);
-  const rollbackTransforms = verifiedRollback.transforms.slice(targetLevel);
+  const remainingTransforms = verifiedRollback.transforms.slice(targetLevel);
 
-  if (!rollbackTransforms.length) {
+  const shouldDelete = [remainingTransforms, failed].every(
+    (arr) => !arr.length
+  );
+
+  if (shouldDelete) {
     process.stdout.write("Deleting rollback file...");
     await unlink(targetPath);
-  } else {
-    process.stdout.write("Updating rollback file...");
-    const newRollbackFile: RollbackFile = {
-      sourcePath,
-      transforms: rollbackTransforms,
-    };
-    await writeFile(
-      resolve(targetDir, ROLLBACK_FILE_NAME),
-      JSON.stringify(newRollbackFile, undefined, 2),
-      "utf-8"
+    process.stdout.write("DONE!");
+    return;
+  }
+
+  let mappedFailed: RenameItemsArray = [];
+  if (failed.length) {
+    const mappedEntry = new Map() as Map<string, RenameItem>;
+
+    remainingTransforms[0]?.reduce(
+      (map, curr) => map.set(curr.referenceId, curr),
+      mappedEntry
+    );
+
+    !mappedEntry.size ? mappedFailed = [...failed] :
+      failed.forEach(({ rename, original, referenceId }) => {
+        const ref = mappedEntry.get(referenceId);
+        if (!ref) return mappedFailed.push({ rename, original, referenceId });
+
+        const isDistinct = original !== ref.rename;
+          mappedFailed.push({
+            rename,
+            original: isDistinct ? ref.rename : original,
+            referenceId,
+          });
+      });
+    
+    console.log(
+      "Failed restore items will be appended to most recent rollback entry."
     );
   }
+
+  const newRollbackFile: RollbackFile = {
+    sourcePath,
+    transforms: [[...mappedFailed], ...remainingTransforms].filter(
+      (entry) => entry.length
+    ),
+  };
+
+  process.stdout.write("Updating rollback file...");
+  await writeFile(
+    resolve(targetDir, ROLLBACK_FILE_NAME),
+    JSON.stringify(newRollbackFile, undefined, 2),
+    "utf-8"
+  );
 
   process.stdout.write("DONE!");
 };
@@ -391,34 +430,46 @@ export const createBatchRenameList: CreateBatchRenameList = ({
 
 /**Remove entries from the list for which the renaming operation
  * resulted in a rejected promise. */
-export const settledPromisesEval = ({
+export const settledPromisesEval = <
+  T extends G[],
+  G extends BaseRenameItem | RenameItem
+>({
   transformedNames,
   promiseResults,
   operationType,
 }: {
-  transformedNames: BaseRenameItem[];
-  promiseResults: PromiseSettledResult<void>[];
+  transformedNames: T;
+  promiseResults: (PromiseFulfilledResult<void> | PromiseRejectedWriteResult)[];
   operationType: "convert" | "restore";
-}): BaseRenameItem[] => {
+}): { successful: T; failed: T } => {
+  const failed = [] as unknown as T;
   const promisesRejected = promiseResults.filter(
     (settledResult) => settledResult.status === "rejected"
   ).length;
 
-  if (promisesRejected === 0) return transformedNames;
+  if (promisesRejected === 0) return { successful: transformedNames, failed };
   if (promisesRejected === transformedNames.length)
     throw new Error(allRenameFailed);
 
   console.log(failReport(promisesRejected, operationType));
-  const truncatedList: BaseRenameItem[] = [];
-  promiseResults.forEach((settledResult, index) => {
+
+  const transformMap = transformedNames.reduce(
+    (map, curr) => map.set(curr.rename, { ...curr }),
+    new Map() as Map<string, G>
+  );
+
+  promiseResults.forEach((settledResult) => {
     if (settledResult.status === "rejected") {
-      const { original, rename } = transformedNames[index];
-      console.log(failItem(original, rename, operationType));
-      return;
+      const { path, dest } = settledResult.reason;
+      const origin = parse(path).base,
+        destination = parse(dest).base;
+      console.log(failItem(origin, destination, operationType));
+      const targetProp = operationType === "convert" ? destination : origin;
+      failed.push(transformMap.get(targetProp)!);
+      transformMap.delete(targetProp);
     }
-    return truncatedList.push(transformedNames[index]);
   });
-  return truncatedList;
+  return { successful: [...transformMap.values()] as T, failed };
 };
 
 /** Will truncate baseName to the length of the supplied truncate argument

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -67,7 +67,7 @@
     // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
 
     /* Interop Constraints */
-    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
     "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */,
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
@@ -98,6 +98,6 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "src/tests/tests-resolver.js"],
   "exclude": ["src/tests"]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,7 +26,6 @@ export default {
   },
   resolve: {
     extensionAlias: { ".js": [".ts", ".js"] },
-    /* plugins: [new ResolveTypescriptPlugin()],*/
   },
   output: {
     path: resolve(__dirname, "prod"),


### PR DESCRIPTION
- Implement multi level rollback with support for legacy rollback files.
- Implemented checks for write operation failures so these are 1) logged and omitted from the rollback file in conversions; 2) logged and re-added to the rollback file for restores.
- Conversions and restores now run in DryRun mode by default (with the exception of cleanRollbackFile).
- Documentation update.
- Various bugfixes (prevent some converters from returning identical transforms, etc.)
- Type improvements, test improvements, mocks consolidation.