### PR TITLE
Feature/list-files-sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - **Convert and restore operations run in dryRun by default** so that changes can be previewed and executed via explicit confirmation. 
   - The `cleanRollbackFile` is an exception currently: it will run immediately, without confirm prompt.
 - **Ability to skip writing rollback file** on transform operations: by using the `skipRollback` option.
+- **Ensure alphabetical sorting of read files and directories**: Ascending alphabetical sorting. Directories placed before files.
 - Various bug fixes. Test improvements, mock files consolidation.
 
 - Despite best efforts and improved tests for the new features, some **buggy behavior can occur**.

--- a/src/tests/mocks.ts
+++ b/src/tests/mocks.ts
@@ -35,15 +35,14 @@ export const mockDirentEntryAsFile: Omit<Dirent, "name"> = {
     return false;
   },
 };
-export const mockFileList: Dirent[] = [
-  "someFile.with.extra.dots.ext",
+export const mockFileNames = ["someFile.with.extra.dots.ext",
   "shortFile.ext",
   "fileWithoutExt",
   ".startWithDot",
   ".startWithDot.ext",
   "UTF-čšžäöüéŁ.ext",
-  "12345-and-chars.ext",
-].map((fileName) => ({ name: fileName, ...mockDirentEntryAsFile }));
+  "12345-and-chars.ext"];
+export const mockFileList: Dirent[] = mockFileNames.map((fileName) => ({ name: fileName, ...mockDirentEntryAsFile }));
 
 const ext = ".ext";
 export const examplePath = "A:/path/to/file";

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -145,6 +145,14 @@ export const listFiles: ListFiles = async (
       if (targetType === "all") return dirEntry;
       if (targetType === "files") return dirEntry.isFile();
       return dirEntry.isDirectory();
+    })
+    // Sort the file list by names alphabetically and ascending.
+    .sort((a, b) => (a.name === b.name ? 0 : a.name < b.name ? -1 : 1))
+    // Directories should be listed first
+    .sort((a, b) => {
+      const aVal = a.isDirectory() ? -1 : 1,
+        bVal = b.isDirectory() ? -1 : 1;
+      return aVal === bVal ? 0 : aVal < bVal ? -1 : 1;
     });
   if (excludeFilter) {
     // Global flag should not be used, as inconsistent results will occur
@@ -216,8 +224,8 @@ export const willOverWriteExisting = (
     .map(({ baseName, ext }) => `${baseName}${ext}`)
     .filter((existingName) => !originals.includes(existingName));
   if (!fileListWithoutTransforms.length) return false;
-  return fileListWithoutTransforms.some(
-    (existingName) => renames.includes(existingName)
+  return fileListWithoutTransforms.some((existingName) =>
+    renames.includes(existingName)
   );
 };
 


### PR DESCRIPTION
Ensure that files and folders, read by readdir are sorted in ascending alphabetical order and that directories are placed before files.